### PR TITLE
feat(camara): suporta id_deputado_autor em buscar_proposicao

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 Todas as mudanças notáveis do mcp-brasil estão documentadas neste arquivo.
 
+## [Unreleased]
+
+### Features
+
+- **camara:** Add `id_deputado_autor` filter to `buscar_proposicao`
+
 ## [0.8.0] - 2026-03-29
 
 ### Documentation

--- a/docs/reference/features.md
+++ b/docs/reference/features.md
@@ -71,7 +71,7 @@ Deputados, proposicoes, votacoes, despesas, comissoes, frentes parlamentares.
 |------|-----------|
 | `camara_listar_deputados` | Lista deputados com filtros (nome, partido, UF) |
 | `camara_buscar_deputado` | Detalhes de um deputado por ID |
-| `camara_buscar_proposicao` | Projetos de lei por tipo, ano, tema, autor |
+| `camara_buscar_proposicao` | Projetos de lei por tipo, ano, tema, autor ou deputado autor |
 | `camara_detalhar_proposicao` | Detalhes completos de uma proposicao por ID |
 | `camara_consultar_tramitacao` | Historico de tramitacao de uma proposicao |
 | `camara_buscar_votacao` | Sessoes de votacao |

--- a/src/mcp_brasil/data/camara/client.py
+++ b/src/mcp_brasil/data/camara/client.py
@@ -248,6 +248,7 @@ async def buscar_proposicoes(
     numero: int | None = None,
     ano: int | None = None,
     keywords: str | None = None,
+    id_deputado_autor: int | None = None,
     pagina: int = 1,
 ) -> list[Proposicao]:
     """Busca proposições com filtros."""
@@ -265,6 +266,8 @@ async def buscar_proposicoes(
         params["ano"] = ano
     if keywords:
         params["keywords"] = keywords
+    if id_deputado_autor is not None:
+        params["idDeputadoAutor"] = id_deputado_autor
     data = await _get(PROPOSICOES_URL, params)
     return [_parse_proposicao(p) for p in _safe_list(data, "proposicoes")]
 

--- a/src/mcp_brasil/data/camara/tools.py
+++ b/src/mcp_brasil/data/camara/tools.py
@@ -101,17 +101,20 @@ async def buscar_proposicao(
     numero: int | None = None,
     ano: int | None = None,
     keywords: str | None = None,
+    id_deputado_autor: int | None = None,
     pagina: int = 1,
 ) -> str:
     """Busca proposições legislativas (PL, PEC, MPV, etc.).
 
-    Permite filtrar por tipo, número, ano ou palavras-chave na ementa.
+    Permite filtrar por tipo, número, ano, palavras-chave na ementa ou
+    pelo ID do deputado autor.
 
     Args:
         sigla_tipo: Tipo da proposição (ex: PL, PEC, MPV, PLP, PDL).
         numero: Número da proposição.
         ano: Ano da proposição.
         keywords: Palavras-chave para busca na ementa.
+        id_deputado_autor: ID do deputado autor da proposição na Câmara.
         pagina: Página de resultados (padrão: 1).
 
     Returns:
@@ -122,6 +125,7 @@ async def buscar_proposicao(
         numero=numero,
         ano=ano,
         keywords=keywords,
+        id_deputado_autor=id_deputado_autor,
         pagina=pagina,
     )
     if not proposicoes:

--- a/tests/data/camara/test_client.py
+++ b/tests/data/camara/test_client.py
@@ -163,6 +163,24 @@ class TestBuscarProposicoes:
 
     @pytest.mark.asyncio
     @respx.mock
+    async def test_passes_author_filter(self) -> None:
+        route = respx.get(
+            PROPOSICOES_URL,
+            params={
+                "pagina": 1,
+                "itens": 15,
+                "ordem": "DESC",
+                "ordenarPor": "id",
+                "idDeputadoAutor": 204554,
+            },
+        ).mock(return_value=httpx.Response(200, json={"dados": [], "links": []}))
+
+        result = await client.buscar_proposicoes(id_deputado_autor=204554)
+        assert result == []
+        assert route.called
+
+    @pytest.mark.asyncio
+    @respx.mock
     async def test_empty(self) -> None:
         respx.get(PROPOSICOES_URL).mock(
             return_value=httpx.Response(200, json={"dados": [], "links": []})

--- a/tests/data/camara/test_integration.py
+++ b/tests/data/camara/test_integration.py
@@ -92,7 +92,10 @@ class TestToolExecution:
             return_value=mock_data,
         ):
             async with Client(mcp) as c:
-                result = await c.call_tool("buscar_proposicao", {"sigla_tipo": "PL", "ano": 2024})
+                result = await c.call_tool(
+                    "buscar_proposicao",
+                    {"sigla_tipo": "PL", "ano": 2024, "id_deputado_autor": 204554},
+                )
                 assert "Proposição E2E" in result.data
 
     @pytest.mark.asyncio

--- a/tests/data/camara/test_tools.py
+++ b/tests/data/camara/test_tools.py
@@ -104,12 +104,37 @@ class TestBuscarProposicao:
             )
         ]
         with patch(f"{MODULE}.buscar_proposicoes", new_callable=AsyncMock, return_value=mock_data):
-            result = await tools.buscar_proposicao(sigla_tipo="PL", ano=2024)
+            result = await tools.buscar_proposicao(
+                sigla_tipo="PL",
+                ano=2024,
+                id_deputado_autor=204554,
+            )
         assert "PL" in result
         assert "1234" in result
         assert "2300001" in result
         assert "educação" in result
         assert "detalhar_proposicao" in result
+
+    @pytest.mark.asyncio
+    async def test_passes_author_filter(self) -> None:
+        with patch(
+            f"{MODULE}.buscar_proposicoes",
+            new_callable=AsyncMock,
+            return_value=[],
+        ) as mocked:
+            await tools.buscar_proposicao(
+                sigla_tipo="PL",
+                ano=2024,
+                id_deputado_autor=204554,
+            )
+        mocked.assert_awaited_once_with(
+            sigla_tipo="PL",
+            numero=None,
+            ano=2024,
+            keywords=None,
+            id_deputado_autor=204554,
+            pagina=1,
+        )
 
     @pytest.mark.asyncio
     async def test_empty(self) -> None:


### PR DESCRIPTION
## Resumo

Adiciona o parâmetro opcional `id_deputado_autor` em `camara_buscar_proposicao`.

## Motivação

Hoje a tool permite buscar proposições por tipo, número, ano e palavras-chave, mas não por autoria de deputado. Isso faz com que fluxos parlamentares estruturados dependam de busca textual, o que não é confiável o suficiente para evidência de autoria.

A API oficial da Câmara já suporta esse vínculo estrutural, então esta mudança amplia o wrapper sem adicionar comportamento específico de um projeto consumidor.

Closes #3.

## Mudanças

- adiciona `id_deputado_autor?: integer` ao schema de entrada da tool
- encaminha o parâmetro para o endpoint de proposições da Câmara como `idDeputadoAutor`
- mantém o comportamento atual inalterado quando o parâmetro não é informado
- atualiza documentação e changelog
- adiciona cobertura de client, tool e integração

## Validação

- `uv run pytest tests/data/camara/test_client.py tests/data/camara/test_tools.py tests/data/camara/test_integration.py -v`
- `uv run ruff check src/mcp_brasil/data/camara/ tests/data/camara/`
- `uv run mypy src/mcp_brasil/data/camara/`

## Observações

Este PR é intencionalmente estreito.

Não adiciona:
- suporte a relatoria
- interpretação ou score
- agregação específica de consumidores
