### PR TITLE
feat(tce_pa): add Diário Oficial, sessões, jurisprudência e conteúdo

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,12 +4,12 @@
 
 # mcp-brasil
 
-**MCP Server para 41 APIs públicas brasileiras**
+**MCP Server para 42 APIs públicas brasileiras**
 
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
-363 tools · 87 resources · 62 prompts · 11 áreas temáticas
+367 tools · 87 resources · 62 prompts · 11 áreas temáticas
 
 Conecte AI agents (Claude, GPT, Copilot, etc.) a dados governamentais do Brasil — economia, legislação, transparência, judiciário, eleições, meio ambiente, saúde, segurança pública e mais.
 
@@ -23,7 +23,7 @@ Conecte AI agents (Claude, GPT, Copilot, etc.) a dados governamentais do Brasil 
 
 ## Features
 
-- **363 tools** em 41 features cobrindo 11 áreas — economia, legislativo, transparência, judiciário, eleitoral, ambiental, saúde, segurança pública, compras públicas, utilidades e mais
+- **367 tools** em 42 features cobrindo 11 áreas — economia, legislativo, transparência, judiciário, eleitoral, ambiental, saúde, segurança pública, compras públicas, utilidades e mais
 - **Cross-referencing** com `planejar_consulta` — cria planos de execução combinando múltiplas APIs (ex: gastos de um deputado + votações + proposições)
 - **Execução em lote** com `executar_lote` — dispara consultas em paralelo numa única chamada
 - **Smart discovery** — BM25 search transform filtra 363 tools para só mostrar as relevantes ao contexto
@@ -151,6 +151,7 @@ Conecte o server e faça perguntas em linguagem natural:
 | `tce_pi` | TCE-PI — prefeituras, despesas, receitas | 5 |
 | `tce_sc` | TCE-SC — municípios e unidades gestoras | 2 |
 | `tce_to` | TCE-TO — processos, pautas de sessões | 3 |
+| `tce_pa` | TCE-PA — Diário Oficial, sessões plenárias, jurisprudência (acórdãos, resoluções, portarias, prejulgados) e conteúdo informativo | 4 |
 
 ### Judiciário
 

--- a/src/mcp_brasil/data/tce_pa/__init__.py
+++ b/src/mcp_brasil/data/tce_pa/__init__.py
@@ -1,0 +1,15 @@
+"""Feature TCE-PA — Tribunal de Contas do Estado do Pará."""
+
+from mcp_brasil._shared.feature import FeatureMeta
+
+FEATURE_META = FeatureMeta(
+    name="tce_pa",
+    description=(
+        "TCE-PA: publicações do Diário Oficial do Tribunal de Contas do Estado "
+        "do Pará via API de Dados Abertos (disponível a partir de 2018)."
+    ),
+    version="0.1.0",
+    api_base="https://sistemas.tcepa.tc.br/dadosabertos/api",
+    requires_auth=False,
+    tags=["tce", "pa", "diario-oficial", "pará"],
+)

--- a/src/mcp_brasil/data/tce_pa/__init__.py
+++ b/src/mcp_brasil/data/tce_pa/__init__.py
@@ -5,11 +5,12 @@ from mcp_brasil._shared.feature import FeatureMeta
 FEATURE_META = FeatureMeta(
     name="tce_pa",
     description=(
-        "TCE-PA: publicações do Diário Oficial do Tribunal de Contas do Estado "
-        "do Pará via API de Dados Abertos (disponível a partir de 2018)."
+        "TCE-PA: Diário Oficial, sessões plenárias, jurisprudência (acórdãos, "
+        "resoluções, portarias, prejulgados) e conteúdo informativo do Tribunal "
+        "de Contas do Estado do Pará via API de Dados Abertos e Pesquisa Integrada."
     ),
     version="0.1.0",
     api_base="https://sistemas.tcepa.tc.br/dadosabertos/api",
     requires_auth=False,
-    tags=["tce", "pa", "diario-oficial", "pará"],
+    tags=["tce", "pa", "diario-oficial", "sessoes", "acordaos", "jurisprudencia", "pará"],
 )

--- a/src/mcp_brasil/data/tce_pa/client.py
+++ b/src/mcp_brasil/data/tce_pa/client.py
@@ -1,18 +1,39 @@
-"""HTTP client for the TCE-PA Dados Abertos API.
+"""HTTP client for the TCE-PA Dados Abertos API and Pesquisa Integrada.
 
 Endpoints:
     GET /v1/diario_oficial → buscar_diario_oficial
+    GET /pesquisaintegrada/pesquisa/resultados → buscar_sessoes_plenarias
+    GET /pesquisaintegrada/pesquisa/resultados → buscar_pesquisa_integrada
 """
 
 from __future__ import annotations
 
+import contextlib
 import re
 from typing import Any
 
-from mcp_brasil._shared.http_client import http_get
+from bs4 import BeautifulSoup
 
-from .constants import DIARIO_OFICIAL_URL
-from .schemas import DiarioOficial
+from mcp_brasil._shared.http_client import create_client, http_get
+from mcp_brasil.exceptions import HttpClientError
+
+from .constants import (
+    BASES_PDF_DOWNLOAD,
+    DIARIO_OFICIAL_URL,
+    SESSOES_DEFAULT_RPP,
+    SESSOES_SEARCH_URL,
+    TIPO_SESSAO,
+)
+from .schemas import DiarioOficial, ResultadoPesquisa, SessaoPlenaria
+
+
+def _build_query(query: str, ano: int | None, mes: int | None) -> str:
+    parts = [query] if query else []
+    if ano:
+        parts.append(f"ano:{ano}")
+    if mes:
+        parts.append(f"mes:{mes:02d}")
+    return " ".join(parts)
 
 
 def _strip_html(text: str) -> str:
@@ -21,6 +42,7 @@ def _strip_html(text: str) -> str:
 
 
 async def buscar_diario_oficial(
+    *,
     ano: int = 2018,
     mes: int | None = None,
     numero_publicacao: int | None = None,
@@ -61,3 +83,193 @@ async def buscar_diario_oficial(
         )
         for item in items
     ]
+
+
+async def buscar_sessoes_plenarias(
+    *,
+    tipo: str = "sessoes",
+    query: str = "",
+    ano: int | None = None,
+    mes: int | None = None,
+    pagina: int = 1,
+    rpp: int = SESSOES_DEFAULT_RPP,
+) -> list[SessaoPlenaria]:
+    """Scrape TCE-PA Pesquisa Integrada for plenary sessions.
+
+    Args:
+        tipo: Database type — "sessoes", "pautas", "atas", or "videos".
+        query: Free-text search query (optional).
+        ano: Year filter (optional).
+        mes: Month filter 1-12 (optional, approximate text search).
+        pagina: Page number (default: 1).
+        rpp: Results per page (default: 20).
+
+    Returns:
+        List of SessaoPlenaria records.
+    """
+    slug = TIPO_SESSAO[tipo]
+    q = _build_query(query, ano, mes)
+
+    params: dict[str, str] = {
+        "b": slug,
+        "q": q,
+        "p": str(pagina),
+        "rpp": str(rpp),
+        "o": "data",
+        "or": "True",
+    }
+
+    async with create_client(headers={"Accept": "text/html,application/xhtml+xml"}) as http:
+        try:
+            resp = await http.get(SESSOES_SEARCH_URL, params=params)
+            resp.raise_for_status()
+        except Exception as exc:
+            raise HttpClientError(f"TCE-PA sessões plenárias failed: {exc}") from exc
+
+    return _parse_sessoes_html(resp.text, tipo=tipo)
+
+
+def _parse_sessoes_html(html: str, *, tipo: str) -> list[SessaoPlenaria]:
+    soup = BeautifulSoup(html, "lxml")
+    results: list[SessaoPlenaria] = []
+
+    for card in soup.select("div.resultado-organico"):
+        title_a = card.select_one("h2.resultado-organico-titulo a.titulo")
+        if not title_a:
+            continue
+
+        titulo = title_a.get_text(strip=True)
+        raw_href = str(title_a.get("href") or "")
+        # Strip query params and /conteudo-original suffix
+        clean_href = raw_href.split("?")[0].removesuffix("/conteudo-original")
+
+        m = re.search(r"/codigo/(\d+)/", clean_href)
+        codigo = int(m.group(1)) if m else None
+
+        # Extract named campos
+        tipo_sessao: str | None = None
+        data_sessao: str | None = None
+        ano_val: int | None = None
+
+        for campo in card.select("div.resultado-organico-campo"):
+            nome_el = campo.select_one("dfn.resultado-organico-campo-nome")
+            valor_el = campo.select_one("span.resultado-organico-campo-valor")
+            if not nome_el or not valor_el:
+                continue
+            nome = nome_el.get_text(strip=True).lower()
+            valor = valor_el.get_text(strip=True)
+            if "tipo" in nome:
+                tipo_sessao = valor
+            elif "data" in nome:
+                data_sessao = valor
+            elif "ano" in nome:
+                with contextlib.suppress(ValueError):
+                    ano_val = int(valor)
+
+        url_documento = _build_doc_url(clean_href, tipo)
+
+        results.append(
+            SessaoPlenaria(
+                codigo=codigo,
+                titulo=titulo,
+                data_sessao=data_sessao,
+                tipo_sessao=tipo_sessao,
+                ano=ano_val,
+                url_pagina=clean_href,
+                url_documento=url_documento,
+            )
+        )
+
+    return results
+
+
+def _build_doc_url(base_url: str, tipo: str) -> str | None:
+    if tipo in ("pautas", "atas"):
+        return f"{base_url}/download"
+    if tipo == "videos":
+        return f"{base_url}/conteudo-original"
+    return None
+
+
+async def buscar_pesquisa_integrada(
+    *,
+    slug: str,
+    query: str = "",
+    ano: int | None = None,
+    mes: int | None = None,
+    pagina: int = 1,
+    rpp: int = SESSOES_DEFAULT_RPP,
+) -> list[ResultadoPesquisa]:
+    """Scrape TCE-PA Pesquisa Integrada for any database.
+
+    Args:
+        slug: Exact database slug (e.g. "acordaos", "resolucoes").
+        query: Free-text search query (optional).
+        ano: Year filter appended to query (optional).
+        mes: Month filter 1-12 (optional, approximate text search).
+        pagina: Page number (default: 1).
+        rpp: Results per page (default: 20).
+
+    Returns:
+        List of ResultadoPesquisa records.
+    """
+    q = _build_query(query, ano, mes)
+
+    params: dict[str, str] = {
+        "b": slug,
+        "q": q,
+        "p": str(pagina),
+        "rpp": str(rpp),
+        "o": "data",
+        "or": "True",
+    }
+
+    async with create_client(headers={"Accept": "text/html,application/xhtml+xml"}) as http:
+        try:
+            resp = await http.get(SESSOES_SEARCH_URL, params=params)
+            resp.raise_for_status()
+        except Exception as exc:
+            raise HttpClientError(f"TCE-PA pesquisa integrada ({slug}) failed: {exc}") from exc
+
+    return _parse_resultados_html(resp.text, slug=slug)
+
+
+def _parse_resultados_html(html: str, *, slug: str) -> list[ResultadoPesquisa]:
+    soup = BeautifulSoup(html, "lxml")
+    results: list[ResultadoPesquisa] = []
+
+    for card in soup.select("div.resultado-organico"):
+        title_a = card.select_one("h2.resultado-organico-titulo a.titulo")
+        if not title_a:
+            continue
+
+        titulo = title_a.get_text(strip=True)
+        raw_href = str(title_a.get("href") or "")
+        clean_href = raw_href.split("?")[0].removesuffix("/conteudo-original")
+
+        campos: dict[str, str] = {}
+        for campo in card.select("div.resultado-organico-campo"):
+            nome_el = campo.select_one("dfn.resultado-organico-campo-nome")
+            valor_el = campo.select_one("span.resultado-organico-campo-valor")
+            if nome_el and valor_el:
+                nome = nome_el.get_text(strip=True).rstrip(":")
+                valor = valor_el.get_text(strip=True)
+                if nome and valor and nome.lower() != "fonte":
+                    campos[nome] = valor[:200]
+
+        url_documento = (
+            f"{clean_href}/download"
+            if slug in BASES_PDF_DOWNLOAD
+            else f"{clean_href}/conteudo-original"
+        )
+
+        results.append(
+            ResultadoPesquisa(
+                titulo=titulo,
+                url_pagina=clean_href,
+                url_documento=url_documento,
+                campos=campos,
+            )
+        )
+
+    return results

--- a/src/mcp_brasil/data/tce_pa/client.py
+++ b/src/mcp_brasil/data/tce_pa/client.py
@@ -1,0 +1,63 @@
+"""HTTP client for the TCE-PA Dados Abertos API.
+
+Endpoints:
+    GET /v1/diario_oficial → buscar_diario_oficial
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+from mcp_brasil._shared.http_client import http_get
+
+from .constants import DIARIO_OFICIAL_URL
+from .schemas import DiarioOficial
+
+
+def _strip_html(text: str) -> str:
+    """Remove HTML tags from a string, preserving whitespace."""
+    return re.sub(r"<[^>]+>", " ", text).strip()
+
+
+async def buscar_diario_oficial(
+    ano: int = 2018,
+    mes: int | None = None,
+    numero_publicacao: int | None = None,
+    tipo_ato: str | None = None,
+) -> list[DiarioOficial]:
+    """Search TCE-PA Diário Oficial publications.
+
+    Args:
+        ano: Year to search (default: 2018, minimum: 2018).
+        mes: Month (1-12, optional).
+        numero_publicacao: Specific publication number (optional).
+        tipo_ato: Filter by act type (optional). Valid values:
+            "Atos de Pessoal para Fins de Registro",
+            "Atos e Normas", "Contratos",
+            "Convênios e Instrumentos Congêneres",
+            "Licitações", "Outros Atos de Pessoal".
+
+    Returns:
+        List of Diário Oficial publications.
+    """
+    params: dict[str, str] = {"ano": str(ano)}
+    if mes is not None:
+        params["mes"] = str(mes)
+    if numero_publicacao is not None:
+        params["numero_publicacao"] = str(numero_publicacao)
+    if tipo_ato:
+        params["tipo_ato"] = tipo_ato
+
+    data: dict[str, Any] = await http_get(DIARIO_OFICIAL_URL, params=params)
+
+    items = data.get("data", []) if isinstance(data, dict) else data
+    return [
+        DiarioOficial(
+            numero_publicacao=item.get("NumeroPublicacao"),
+            data_publicacao=item.get("DataPublicacao", ""),
+            tipo_ato=item.get("TipoAto", ""),
+            publicacao=_strip_html(item.get("Publicacao", "")),
+        )
+        for item in items
+    ]

--- a/src/mcp_brasil/data/tce_pa/constants.py
+++ b/src/mcp_brasil/data/tce_pa/constants.py
@@ -1,0 +1,16 @@
+"""Constants for the TCE-PA feature."""
+
+API_BASE = "https://sistemas.tcepa.tc.br/dadosabertos/api"
+
+# Endpoint — Diário Oficial publications (year 2018+)
+DIARIO_OFICIAL_URL = f"{API_BASE}/v1/diario_oficial"
+
+# Valid TipoAto values accepted by the API
+TIPO_ATO = {
+    "PESSOAL_REGISTRO": "Atos de Pessoal para Fins de Registro",
+    "ATOS_NORMAS": "Atos e Normas",
+    "CONTRATOS": "Contratos",
+    "CONVENIOS": "Convênios e Instrumentos Congêneres",
+    "LICITACOES": "Licitações",
+    "OUTROS_PESSOAL": "Outros Atos de Pessoal",
+}

--- a/src/mcp_brasil/data/tce_pa/constants.py
+++ b/src/mcp_brasil/data/tce_pa/constants.py
@@ -14,3 +14,51 @@ TIPO_ATO = {
     "LICITACOES": "Licitações",
     "OUTROS_PESSOAL": "Outros Atos de Pessoal",
 }
+
+# Pesquisa Integrada — Sessões Plenárias
+PESQUISA_BASE_URL = "https://www.tcepa.tc.br/pesquisaintegrada"
+SESSOES_SEARCH_URL = f"{PESQUISA_BASE_URL}/pesquisa/resultados"
+
+# Database slugs for each type
+TIPO_SESSAO: dict[str, str] = {
+    "sessoes": "sessoes-plenarias",
+    "pautas": "pautas-sessoes-plenarias",
+    "atas": "atas-extratos-sessoes-plenarias",
+    "videos": "videos-sessoes-plenarias",
+}
+
+SESSOES_DEFAULT_RPP = 20
+
+# Pesquisa Integrada — Jurisprudência
+BASES_JURISPRUDENCIA: dict[str, str] = {
+    "acordaos": "acordaos",
+    "acordaos-virtual": "acordaos-plenario-virtual",
+    "resolucoes": "resolucoes",
+    "portarias": "portarias-tcepa",
+    "atos": "atos",
+    "informativos": "informativos-jurisprudencia",
+    "prejulgados": "prejulgados",
+}
+
+# Pesquisa Integrada — Comunicação e Educação
+BASES_CONTEUDO: dict[str, str] = {
+    "noticias": "noticias-portal-internet",
+    "acervo": "acervo-bibliografico",
+    "educacao": "acoes-educacionais",
+    "youtube": "canal-youtube-tce-pa",
+    "imagens": "banco-imagens",
+}
+
+# Bases cujo documento é PDF (usa /download); restantes usam /conteudo-original
+BASES_PDF_DOWNLOAD = {
+    "acordaos",
+    "acordaos-plenario-virtual",
+    "resolucoes",
+    "portarias-tcepa",
+    "atos",
+    "informativos-jurisprudencia",
+    "prejulgados",
+    "acervo-bibliografico",
+    "atas-extratos-sessoes-plenarias",
+    "pautas-sessoes-plenarias",
+}

--- a/src/mcp_brasil/data/tce_pa/prompts.py
+++ b/src/mcp_brasil/data/tce_pa/prompts.py
@@ -3,6 +3,82 @@
 from __future__ import annotations
 
 
+def explorar_conteudo_pa(query: str = "", ano: int | None = None) -> str:
+    """Exploração de conteúdo informativo do TCE-PA.
+
+    Guia o LLM para buscar notícias, acervo bibliográfico, ações educacionais,
+    vídeos do YouTube e banco de imagens do TCE-PA.
+
+    Args:
+        query: Termo de busca (ex: "licitação", "capacitação", "fiscalização").
+        ano: Ano de referência (opcional).
+    """
+    ano_param = f", ano={ano}" if ano else ""
+    query_param = f", query='{query}'" if query else ""
+
+    return (
+        "Explore o conteúdo informativo do TCE-PA"
+        + (f" sobre '{query}'" if query else "")
+        + (f" de {ano}" if ano else "")
+        + ".\n\n"
+        "Siga estes passos:\n\n"
+        f"1. Use `buscar_conteudo_pa` com base='noticias'{query_param}{ano_param}"
+        " para buscar notícias do portal do TCE-PA.\n"
+        f"2. Use `buscar_conteudo_pa` com base='educacao'{query_param}{ano_param}"
+        " para ações educacionais e cursos oferecidos.\n"
+        f"3. Use `buscar_conteudo_pa` com base='acervo'{query_param}{ano_param}"
+        " para publicações e obras do acervo bibliográfico.\n"
+        f"4. Use `buscar_conteudo_pa` com base='youtube'{query_param}{ano_param}"
+        " para vídeos no canal oficial do TCE-PA.\n"
+        f"5. Use `buscar_conteudo_pa` com base='imagens'{query_param}{ano_param}"
+        " para o banco de imagens institucional.\n"
+        "6. Para paginar, use o parâmetro pagina (padrão: 1, 20 por página).\n\n"
+        "Apresente um resumo com:\n"
+        "- Notícias e comunicados recentes relevantes ao tema\n"
+        "- Cursos e eventos educacionais disponíveis\n"
+        "- Publicações do acervo relacionadas ao tema\n"
+        "- Links diretos para vídeos e materiais encontrados\n"
+    )
+
+
+def analisar_jurisprudencia_pa(query: str = "", ano: int | None = None) -> str:
+    """Pesquisa de jurisprudência do TCE-PA.
+
+    Guia o LLM para buscar acórdãos, resoluções, portarias, prejulgados
+    e informativos do Tribunal de Contas do Estado do Pará.
+
+    Args:
+        query: Termo de busca (ex: "licitação", "dispensa", "pessoal").
+        ano: Ano de referência (opcional).
+    """
+    ano_info = f" de {ano}" if ano else ""
+    query_info = f" sobre '{query}'" if query else ""
+    ano_param = f", ano={ano}" if ano else ""
+    query_param = f", query='{query}'" if query else ""
+
+    return (
+        f"Pesquise jurisprudência{query_info}{ano_info} no TCE-PA.\n\n"
+        "Siga estes passos:\n\n"
+        f"1. Use `buscar_jurisprudencia_pa` com base='acordaos'{query_param}{ano_param}"
+        " para buscar acórdãos do plenário.\n"
+        f"2. Use `buscar_jurisprudencia_pa` com base='acordaos-virtual'{query_param}{ano_param}"
+        " para acórdãos do plenário virtual.\n"
+        f"3. Use `buscar_jurisprudencia_pa` com base='resolucoes'{query_param}{ano_param}"
+        " para resoluções normativas.\n"
+        f"4. Use `buscar_jurisprudencia_pa` com base='prejulgados'{query_param}{ano_param}"
+        " para prejulgados (teses consolidadas).\n"
+        f"5. Use `buscar_jurisprudencia_pa` com base='portarias'{query_param}{ano_param}"
+        " para portarias do TCE-PA.\n"
+        "6. Para paginar resultados, use o parâmetro pagina (padrão: 1, 20 por página).\n"
+        "7. Os documentos PDF estão disponíveis via url_documento de cada resultado.\n\n"
+        "Apresente um resumo com:\n"
+        "- Acórdãos mais relevantes encontrados e suas decisões\n"
+        "- Resoluções e portarias aplicáveis ao tema pesquisado\n"
+        "- Prejulgados que consolidam entendimento sobre o tema\n"
+        "- Links diretos para os PDFs dos documentos principais\n"
+    )
+
+
 def analisar_diario_oficial_pa(ano: int = 2024, mes: int | None = None) -> str:
     """Análise de publicações do Diário Oficial do TCE-PA.
 
@@ -32,4 +108,34 @@ def analisar_diario_oficial_pa(ano: int = 2024, mes: int | None = None) -> str:
         "- Principais contratos e licitações publicados\n"
         "- Atos normativos relevantes (resoluções, portarias)\n"
         "- Atos de pessoal em destaque\n"
+    )
+
+
+def analisar_sessoes_plenarias_pa(ano: int = 2024) -> str:
+    """Análise de sessões plenárias do TCE-PA.
+
+    Guia o LLM para buscar e analisar sessões plenárias do Tribunal de
+    Contas do Estado do Pará, incluindo pautas, atas e vídeos.
+
+    Args:
+        ano: Ano de referência (padrão: 2024).
+    """
+    return (
+        f"Analise as sessões plenárias do TCE-PA em {ano}.\n\n"
+        "Siga estes passos:\n\n"
+        f"1. Use `buscar_sessoes_plenarias_pa` com tipo='sessoes', ano={ano}"
+        " para listar todas as sessões do ano.\n"
+        f"2. Use `buscar_sessoes_plenarias_pa` com tipo='pautas', ano={ano}"
+        " para obter pautas com links para download dos PDFs.\n"
+        f"3. Use `buscar_sessoes_plenarias_pa` com tipo='atas', ano={ano}"
+        " para obter atas com links para download dos PDFs.\n"
+        f"4. Use `buscar_sessoes_plenarias_pa` com tipo='videos', ano={ano}"
+        " para obter links dos vídeos no YouTube.\n"
+        "5. Para buscar sessões específicas, use o parâmetro query (ex: query='extraordinária').\n"
+        "6. Para navegar além da primeira página, use o parâmetro pagina.\n\n"
+        "Apresente um resumo com:\n"
+        "- Total de sessões realizadas e distribuição por tipo\n"
+        "  (ordinária, extraordinária, plenário virtual)\n"
+        "- Frequência das sessões ao longo do ano\n"
+        "- Disponibilidade de pautas, atas e vídeos por sessão\n"
     )

--- a/src/mcp_brasil/data/tce_pa/prompts.py
+++ b/src/mcp_brasil/data/tce_pa/prompts.py
@@ -1,0 +1,35 @@
+"""Analysis prompts for the TCE-PA feature."""
+
+from __future__ import annotations
+
+
+def analisar_diario_oficial_pa(ano: int = 2024, mes: int | None = None) -> str:
+    """Análise de publicações do Diário Oficial do TCE-PA.
+
+    Guia o LLM para buscar e analisar atos publicados no Diário Oficial
+    do Tribunal de Contas do Estado do Pará em um determinado período.
+
+    Args:
+        ano: Ano de referência (padrão: 2024, mínimo: 2018).
+        mes: Mês específico (1-12, opcional — omita para o ano inteiro).
+    """
+    periodo = f"{mes:02d}/{ano}" if mes else str(ano)
+    mes_param = f", mes={mes}" if mes else ""
+
+    return (
+        f"Analise as publicações do Diário Oficial do TCE-PA em {periodo}.\n\n"
+        "Siga estes passos:\n\n"
+        f"1. Use `buscar_diario_oficial_pa` com ano={ano}{mes_param}"
+        " para obter todas as publicações.\n"
+        "2. Use `buscar_diario_oficial_pa` com"
+        " tipo_ato='Contratos' para filtrar contratos.\n"
+        "3. Use `buscar_diario_oficial_pa` com"
+        " tipo_ato='Licitações' para filtrar licitações.\n"
+        "4. Use `buscar_diario_oficial_pa` com"
+        " tipo_ato='Atos e Normas' para normas e resoluções.\n\n"
+        "Apresente um resumo com:\n"
+        "- Total de publicações por tipo de ato\n"
+        "- Principais contratos e licitações publicados\n"
+        "- Atos normativos relevantes (resoluções, portarias)\n"
+        "- Atos de pessoal em destaque\n"
+    )

--- a/src/mcp_brasil/data/tce_pa/resources.py
+++ b/src/mcp_brasil/data/tce_pa/resources.py
@@ -4,16 +4,24 @@ from __future__ import annotations
 
 import json
 
+_PESQUISA_PARAMS = {
+    "b": "string (obrigatório): slug da base de dados (ver abaixo)",
+    "q": "string (opcional): busca textual, suporta ano:YYYY para filtrar por ano",
+    "p": "integer (opcional): página (padrão: 1)",
+    "rpp": "integer (opcional): resultados por página — 10, 15, 20 ou 25",
+    "o": "string (opcional): relevancia | titulo | data",
+    "or": "bool (opcional): True=decrescente, False=crescente",
+}
+
 
 def endpoints_tce_pa() -> str:
-    """Catálogo de endpoints disponíveis na API de Dados Abertos do TCE-PA.
-
-    Lista o endpoint disponível com seus parâmetros e tipos de ato aceitos.
-    """
+    """Catálogo de endpoints disponíveis na API de Dados Abertos e Pesquisa Integrada do TCE-PA."""
     endpoints = [
         {
             "endpoint": "/v1/diario_oficial",
-            "descricao": ("Publicações do Diário Oficial do TCE-PA a partir de 2018"),
+            "base_url": "https://sistemas.tcepa.tc.br/dadosabertos/api",
+            "descricao": "Publicações do Diário Oficial do TCE-PA a partir de 2018",
+            "ferramenta": "buscar_diario_oficial_pa",
             "parametros": {
                 "ano": "integer (obrigatório, padrão: 2018, mínimo: 2018)",
                 "mes": "integer (opcional, 1-12)",
@@ -28,6 +36,52 @@ def endpoints_tce_pa() -> str:
                 "Licitações",
                 "Outros Atos de Pessoal",
             ],
-        }
+        },
+        {
+            "endpoint": "/pesquisa/resultados",
+            "base_url": "https://www.tcepa.tc.br/pesquisaintegrada",
+            "descricao": "Pesquisa Integrada do TCE-PA — busca textual em múltiplas bases",
+            "parametros": _PESQUISA_PARAMS,
+            "bases": {
+                "sessoes_plenarias": {
+                    "ferramenta": "buscar_sessoes_plenarias_pa",
+                    "slugs": {
+                        "sessoes": "sessoes-plenarias",
+                        "pautas": "pautas-sessoes-plenarias",
+                        "atas": "atas-extratos-sessoes-plenarias",
+                        "videos": "videos-sessoes-plenarias",
+                    },
+                    "documentos": {
+                        "pautas": "URL do registro + /download → PDF",
+                        "atas": "URL do registro + /download → PDF",
+                        "videos": "URL do registro + /conteudo-original → YouTube",
+                    },
+                },
+                "jurisprudencia": {
+                    "ferramenta": "buscar_jurisprudencia_pa",
+                    "slugs": {
+                        "acordaos": "acordaos",
+                        "acordaos-virtual": "acordaos-plenario-virtual",
+                        "resolucoes": "resolucoes",
+                        "portarias": "portarias-tcepa",
+                        "atos": "atos",
+                        "informativos": "informativos-jurisprudencia",
+                        "prejulgados": "prejulgados",
+                    },
+                    "documentos": "URL do registro + /download → PDF",
+                },
+                "conteudo": {
+                    "ferramenta": "buscar_conteudo_pa",
+                    "slugs": {
+                        "noticias": "noticias-portal-internet",
+                        "acervo": "acervo-bibliografico",
+                        "educacao": "acoes-educacionais",
+                        "youtube": "canal-youtube-tce-pa",
+                        "imagens": "banco-imagens",
+                    },
+                    "documentos": "URL do registro + /conteudo-original → conteúdo online",
+                },
+            },
+        },
     ]
     return json.dumps(endpoints, ensure_ascii=False, indent=2)

--- a/src/mcp_brasil/data/tce_pa/resources.py
+++ b/src/mcp_brasil/data/tce_pa/resources.py
@@ -1,0 +1,33 @@
+"""Static reference data for the TCE-PA feature."""
+
+from __future__ import annotations
+
+import json
+
+
+def endpoints_tce_pa() -> str:
+    """Catálogo de endpoints disponíveis na API de Dados Abertos do TCE-PA.
+
+    Lista o endpoint disponível com seus parâmetros e tipos de ato aceitos.
+    """
+    endpoints = [
+        {
+            "endpoint": "/v1/diario_oficial",
+            "descricao": ("Publicações do Diário Oficial do TCE-PA a partir de 2018"),
+            "parametros": {
+                "ano": "integer (obrigatório, padrão: 2018, mínimo: 2018)",
+                "mes": "integer (opcional, 1-12)",
+                "numero_publicacao": "integer (opcional)",
+                "tipo_ato": "string (opcional)",
+            },
+            "tipo_ato_valores": [
+                "Atos de Pessoal para Fins de Registro",
+                "Atos e Normas",
+                "Contratos",
+                "Convênios e Instrumentos Congêneres",
+                "Licitações",
+                "Outros Atos de Pessoal",
+            ],
+        }
+    ]
+    return json.dumps(endpoints, ensure_ascii=False, indent=2)

--- a/src/mcp_brasil/data/tce_pa/schemas.py
+++ b/src/mcp_brasil/data/tce_pa/schemas.py
@@ -12,3 +12,24 @@ class DiarioOficial(BaseModel):
     publicacao: str | None = None
     data_publicacao: str | None = None
     tipo_ato: str | None = None
+
+
+class SessaoPlenaria(BaseModel):
+    """Registro de sessão plenária do TCE-PA."""
+
+    codigo: int | None = None
+    titulo: str | None = None
+    data_sessao: str | None = None
+    tipo_sessao: str | None = None
+    ano: int | None = None
+    url_pagina: str | None = None
+    url_documento: str | None = None
+
+
+class ResultadoPesquisa(BaseModel):
+    """Resultado genérico da Pesquisa Integrada do TCE-PA."""
+
+    titulo: str | None = None
+    url_pagina: str | None = None
+    url_documento: str | None = None
+    campos: dict[str, str] = {}

--- a/src/mcp_brasil/data/tce_pa/schemas.py
+++ b/src/mcp_brasil/data/tce_pa/schemas.py
@@ -1,0 +1,14 @@
+"""Pydantic schemas for the TCE-PA feature."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel
+
+
+class DiarioOficial(BaseModel):
+    """Publicação no Diário Oficial do TCE-PA."""
+
+    numero_publicacao: int | None = None
+    publicacao: str | None = None
+    data_publicacao: str | None = None
+    tipo_ato: str | None = None

--- a/src/mcp_brasil/data/tce_pa/server.py
+++ b/src/mcp_brasil/data/tce_pa/server.py
@@ -5,9 +5,19 @@ This file only registers components. Zero business logic (ADR-001 rule #4).
 
 from fastmcp import FastMCP
 
-from .prompts import analisar_diario_oficial_pa
+from .prompts import (
+    analisar_diario_oficial_pa,
+    analisar_jurisprudencia_pa,
+    analisar_sessoes_plenarias_pa,
+    explorar_conteudo_pa,
+)
 from .resources import endpoints_tce_pa
-from .tools import buscar_diario_oficial_pa
+from .tools import (
+    buscar_conteudo_pa,
+    buscar_diario_oficial_pa,
+    buscar_jurisprudencia_pa,
+    buscar_sessoes_plenarias_pa,
+)
 
 mcp = FastMCP("mcp-brasil-tce-pa")
 
@@ -16,9 +26,24 @@ mcp.tool(
     buscar_diario_oficial_pa,
     tags={"busca", "diário-oficial", "tce", "pará"},
 )
+mcp.tool(
+    buscar_sessoes_plenarias_pa,
+    tags={"sessões", "plenária", "pauta", "ata", "extrato", "vídeo", "tce", "pará"},
+)
+mcp.tool(
+    buscar_jurisprudencia_pa,
+    tags={"acórdão", "resolução", "portaria", "jurisprudência", "normas", "tce", "pará"},
+)
+mcp.tool(
+    buscar_conteudo_pa,
+    tags={"notícias", "acervo", "educação", "youtube", "comunicação", "tce", "pará"},
+)
 
 # Resources
 mcp.resource("data://endpoints", mime_type="application/json")(endpoints_tce_pa)
 
 # Prompts
+mcp.prompt(analisar_jurisprudencia_pa)
 mcp.prompt(analisar_diario_oficial_pa)
+mcp.prompt(analisar_sessoes_plenarias_pa)
+mcp.prompt(explorar_conteudo_pa)

--- a/src/mcp_brasil/data/tce_pa/server.py
+++ b/src/mcp_brasil/data/tce_pa/server.py
@@ -1,0 +1,24 @@
+"""tce_pa feature server — registers tools, resources, and prompts.
+
+This file only registers components. Zero business logic (ADR-001 rule #4).
+"""
+
+from fastmcp import FastMCP
+
+from .prompts import analisar_diario_oficial_pa
+from .resources import endpoints_tce_pa
+from .tools import buscar_diario_oficial_pa
+
+mcp = FastMCP("mcp-brasil-tce-pa")
+
+# Tools
+mcp.tool(
+    buscar_diario_oficial_pa,
+    tags={"busca", "diário-oficial", "tce", "pará"},
+)
+
+# Resources
+mcp.resource("data://endpoints", mime_type="application/json")(endpoints_tce_pa)
+
+# Prompts
+mcp.prompt(analisar_diario_oficial_pa)

--- a/src/mcp_brasil/data/tce_pa/tools.py
+++ b/src/mcp_brasil/data/tce_pa/tools.py
@@ -12,7 +12,7 @@ from fastmcp import Context
 from mcp_brasil._shared.formatting import markdown_table
 
 from . import client
-from .constants import TIPO_ATO
+from .constants import BASES_CONTEUDO, BASES_JURISPRUDENCIA, TIPO_ATO, TIPO_SESSAO
 
 
 async def buscar_diario_oficial_pa(
@@ -75,3 +75,221 @@ async def buscar_diario_oficial_pa(
         ["Nº Publicação", "Data", "Tipo de Ato", "Conteúdo (resumo)"],
         rows,
     )
+
+
+async def buscar_sessoes_plenarias_pa(
+    ctx: Context,
+    tipo: str = "sessoes",
+    query: str = "",
+    ano: int | None = None,
+    mes: int | None = None,
+    pagina: int = 1,
+) -> str:
+    """Busca sessões plenárias do TCE-PA via Pesquisa Integrada.
+
+    Pesquisa sessões plenárias, pautas, atas/extratos ou vídeos do
+    Tribunal de Contas do Estado do Pará.
+
+    Args:
+        tipo: Tipo de dado — "sessoes", "pautas", "atas" ou "videos".
+        query: Texto de busca (opcional).
+        ano: Filtro por ano (opcional).
+        mes: Filtro por mês 1-12 (opcional, busca textual aproximada).
+        pagina: Página de resultados (padrão: 1, 20 resultados/página).
+
+    Returns:
+        Tabela com sessões encontradas e links para documentos.
+    """
+    tipos_validos = list(TIPO_SESSAO)
+    if tipo not in tipos_validos:
+        return f"Tipo inválido: '{tipo}'. Use um de: {tipos_validos}"
+
+    await ctx.info(f"Buscando {tipo} de sessões plenárias do TCE-PA (página {pagina})...")
+    sessoes = await client.buscar_sessoes_plenarias(
+        tipo=tipo,
+        query=query,
+        ano=ano,
+        mes=mes,
+        pagina=pagina,
+    )
+
+    if not sessoes:
+        return "Nenhuma sessão encontrada para os filtros informados."
+
+    await ctx.info(f"{len(sessoes)} resultado(s) encontrado(s)")
+
+    tipos_info = ", ".join(tipos_validos)
+    header = (
+        f"**Sessões Plenárias TCE-PA — {tipo}**\n"
+        f"Página {pagina} | {len(sessoes)} resultado(s)\n"
+        f"Tipos disponíveis: {tipos_info}\n\n"
+    )
+
+    if tipo == "sessoes":
+        rows = [
+            (
+                s.data_sessao or "—",
+                (s.titulo or "—")[:55],
+                s.tipo_sessao or "—",
+                str(s.ano or "—"),
+                s.url_pagina or "—",
+            )
+            for s in sessoes
+        ]
+        return header + markdown_table(
+            ["Data", "Título", "Tipo", "Ano", "URL"],
+            rows,
+        )
+
+    rows_doc = [
+        (
+            s.data_sessao or "—",
+            (s.titulo or "—")[:55],
+            s.tipo_sessao or "—",
+            s.url_documento or s.url_pagina or "—",
+        )
+        for s in sessoes
+    ]
+    col_doc = "Vídeo (YouTube)" if tipo == "videos" else "Download PDF"
+    return header + markdown_table(
+        ["Data", "Título", "Tipo", col_doc],
+        rows_doc,
+    )
+
+
+async def buscar_jurisprudencia_pa(
+    ctx: Context,
+    base: str = "acordaos",
+    query: str = "",
+    ano: int | None = None,
+    mes: int | None = None,
+    pagina: int = 1,
+) -> str:
+    """Busca jurisprudência e normas do TCE-PA via Pesquisa Integrada.
+
+    Pesquisa acórdãos, resoluções, portarias, atos, prejulgados e informativos
+    do Tribunal de Contas do Estado do Pará.
+
+    Args:
+        base: Base de dados — "acordaos", "acordaos-virtual", "resolucoes",
+              "portarias", "atos", "informativos", "prejulgados".
+        query: Texto de busca (opcional).
+        ano: Filtro por ano (opcional).
+        mes: Filtro por mês 1-12 (opcional, busca textual aproximada).
+        pagina: Página de resultados (padrão: 1, 20 resultados/página).
+
+    Returns:
+        Tabela com resultados e links para documentos PDF.
+    """
+    bases_validas = list(BASES_JURISPRUDENCIA)
+    if base not in bases_validas:
+        return f"Base inválida: '{base}'. Use: {bases_validas}"
+
+    slug = BASES_JURISPRUDENCIA[base]
+    await ctx.info(f"Buscando {base} no TCE-PA (página {pagina})...")
+    resultados = await client.buscar_pesquisa_integrada(
+        slug=slug, query=query, ano=ano, mes=mes, pagina=pagina
+    )
+
+    if not resultados:
+        return "Nenhum resultado encontrado para os filtros informados."
+
+    await ctx.info(f"{len(resultados)} resultado(s) encontrado(s)")
+
+    bases_info = ", ".join(bases_validas)
+    header = (
+        f"**TCE-PA Jurisprudência — {base}**\n"
+        f"Página {pagina} | {len(resultados)} resultado(s)\n"
+        f"Bases disponíveis: {bases_info}\n\n"
+    )
+
+    # Pick most informative campos per base type
+    if base in ("acordaos", "acordaos-virtual"):
+        campo_data = "Data da sessão plenária"
+        campo_extra = "Decisões"
+    else:
+        campo_data = "Data"
+        campo_extra = "Tipo"
+
+    rows = []
+    for r in resultados:
+        data_val = r.campos.get(campo_data, r.campos.get("Data", "—"))[:30]
+        extra_val = r.campos.get(campo_extra, "—")[:40]
+        rows.append(
+            (
+                data_val,
+                (r.titulo or "—")[:55],
+                extra_val,
+                r.url_documento or r.url_pagina or "—",
+            )
+        )
+
+    return header + markdown_table(["Data", "Título", "Info", "Documento PDF"], rows)
+
+
+async def buscar_conteudo_pa(
+    ctx: Context,
+    base: str = "noticias",
+    query: str = "",
+    ano: int | None = None,
+    mes: int | None = None,
+    pagina: int = 1,
+) -> str:
+    """Busca conteúdo informativo do TCE-PA via Pesquisa Integrada.
+
+    Pesquisa notícias, acervo bibliográfico, ações educacionais,
+    canal YouTube e banco de imagens do TCE-PA.
+
+    Args:
+        base: Base de dados — "noticias", "acervo", "educacao",
+              "youtube", "imagens".
+        query: Texto de busca (opcional).
+        ano: Filtro por ano (opcional).
+        mes: Filtro por mês 1-12 (opcional, busca textual aproximada).
+        pagina: Página de resultados (padrão: 1, 20 resultados/página).
+
+    Returns:
+        Tabela com resultados e links para conteúdo.
+    """
+    bases_validas = list(BASES_CONTEUDO)
+    if base not in bases_validas:
+        return f"Base inválida: '{base}'. Use: {bases_validas}"
+
+    slug = BASES_CONTEUDO[base]
+    await ctx.info(f"Buscando {base} no TCE-PA (página {pagina})...")
+    resultados = await client.buscar_pesquisa_integrada(
+        slug=slug, query=query, ano=ano, mes=mes, pagina=pagina
+    )
+
+    if not resultados:
+        return "Nenhum resultado encontrado para os filtros informados."
+
+    await ctx.info(f"{len(resultados)} resultado(s) encontrado(s)")
+
+    bases_info = ", ".join(bases_validas)
+    header = (
+        f"**TCE-PA Conteúdo — {base}**\n"
+        f"Página {pagina} | {len(resultados)} resultado(s)\n"
+        f"Bases disponíveis: {bases_info}\n\n"
+    )
+
+    # Pick most informative date/summary campo per base
+    data_campo = "Data de publicação" if base == "noticias" else "Data"
+    resumo_campo = "Resumo" if base == "noticias" else "Descrição"
+
+    col_link = "Vídeo (YouTube)" if base == "youtube" else "Link"
+
+    rows = []
+    for r in resultados:
+        data_val = r.campos.get(data_campo, r.campos.get("Ano de publicação", "—"))[:20]
+        resumo_val = r.campos.get(resumo_campo, "—")[:60]
+        rows.append(
+            (
+                data_val,
+                (r.titulo or "—")[:55],
+                resumo_val,
+                r.url_documento or r.url_pagina or "—",
+            )
+        )
+
+    return header + markdown_table(["Data", "Título", "Resumo", col_link], rows)

--- a/src/mcp_brasil/data/tce_pa/tools.py
+++ b/src/mcp_brasil/data/tce_pa/tools.py
@@ -1,0 +1,77 @@
+"""Tool functions for the tce_pa feature.
+
+Rules (ADR-001):
+    - tools.py NEVER makes HTTP directly — delegates to client.py
+    - Returns formatted strings for LLM consumption
+"""
+
+from __future__ import annotations
+
+from fastmcp import Context
+
+from mcp_brasil._shared.formatting import markdown_table
+
+from . import client
+from .constants import TIPO_ATO
+
+
+async def buscar_diario_oficial_pa(
+    ctx: Context,
+    ano: int = 2018,
+    mes: int | None = None,
+    tipo_ato: str | None = None,
+    numero_publicacao: int | None = None,
+) -> str:
+    """Busca publicações no Diário Oficial do TCE-PA.
+
+    Pesquisa atos publicados no Diário Oficial do Tribunal de Contas
+    do Estado do Pará. Os dados estão disponíveis a partir de 2018.
+
+    Args:
+        ano: Ano da publicação (padrão: 2018, mínimo: 2018).
+        mes: Mês (1-12, opcional).
+        tipo_ato: Tipo de ato para filtrar (opcional). Valores válidos:
+            "Atos de Pessoal para Fins de Registro",
+            "Atos e Normas", "Contratos",
+            "Convênios e Instrumentos Congêneres",
+            "Licitações", "Outros Atos de Pessoal".
+        numero_publicacao: Número específico da publicação (opcional).
+
+    Returns:
+        Tabela com publicações encontradas.
+    """
+    await ctx.info(f"Buscando Diário Oficial do TCE-PA ({ano})...")
+    publicacoes = await client.buscar_diario_oficial(
+        ano=ano,
+        mes=mes,
+        numero_publicacao=numero_publicacao,
+        tipo_ato=tipo_ato,
+    )
+
+    if not publicacoes:
+        return "Nenhuma publicação encontrada para os filtros informados."
+
+    await ctx.info(f"{len(publicacoes)} publicação(ões) encontrada(s)")
+
+    tipos_validos = "\n".join(f"  - {v}" for v in TIPO_ATO.values())
+    header = (
+        f"Diário Oficial do TCE-PA — {len(publicacoes)} publicação(ões) encontrada(s):\n\n"
+        f"**Tipos de ato disponíveis:**\n{tipos_validos}\n\n"
+    )
+
+    rows = [
+        (
+            str(p.numero_publicacao) if p.numero_publicacao else "—",
+            p.data_publicacao or "—",
+            p.tipo_ato or "—",
+            (p.publicacao[:80] + "...")
+            if p.publicacao and len(p.publicacao) > 80
+            else (p.publicacao or "—"),
+        )
+        for p in publicacoes
+    ]
+
+    return header + markdown_table(
+        ["Nº Publicação", "Data", "Tipo de Ato", "Conteúdo (resumo)"],
+        rows,
+    )

--- a/tests/data/tce_pa/test_client.py
+++ b/tests/data/tce_pa/test_client.py
@@ -1,0 +1,479 @@
+"""Tests for the TCE-PA HTTP client."""
+
+import httpx
+import pytest
+import respx
+
+from mcp_brasil.data.tce_pa import client
+from mcp_brasil.data.tce_pa.constants import DIARIO_OFICIAL_URL, SESSOES_SEARCH_URL
+
+_HTML_HEADERS = {"content-type": "text/html"}
+
+# ---------------------------------------------------------------------------
+# HTML fixtures
+# ---------------------------------------------------------------------------
+
+_SESSAO_HTML = """
+<html><body>
+<div class="resultado-organico">
+  <h2 class="resultado-organico-titulo">
+    <a class="titulo"
+       href="/pesquisaintegrada/sessoes-plenarias/codigo/42/sessao-01-2024">
+      Sessão Ordinária nº 01/2024
+    </a>
+  </h2>
+  <div class="resultado-organico-campo">
+    <dfn class="resultado-organico-campo-nome">Tipo de Sessão</dfn>
+    <span class="resultado-organico-campo-valor">Ordinária</span>
+  </div>
+  <div class="resultado-organico-campo">
+    <dfn class="resultado-organico-campo-nome">Data da Sessão</dfn>
+    <span class="resultado-organico-campo-valor">15/01/2024</span>
+  </div>
+  <div class="resultado-organico-campo">
+    <dfn class="resultado-organico-campo-nome">Ano</dfn>
+    <span class="resultado-organico-campo-valor">2024</span>
+  </div>
+</div>
+</body></html>
+"""
+
+_RESULTADO_HTML = """
+<html><body>
+<div class="resultado-organico">
+  <h2 class="resultado-organico-titulo">
+    <a class="titulo"
+       href="/pesquisaintegrada/acordaos/codigo/99/acordao-1234-2024">
+      Acórdão nº 1234/2024
+    </a>
+  </h2>
+  <div class="resultado-organico-campo">
+    <dfn class="resultado-organico-campo-nome">Data da sessão plenária</dfn>
+    <span class="resultado-organico-campo-valor">20/03/2024</span>
+  </div>
+  <div class="resultado-organico-campo">
+    <dfn class="resultado-organico-campo-nome">Fonte</dfn>
+    <span class="resultado-organico-campo-valor">TCE-PA</span>
+  </div>
+</div>
+</body></html>
+"""
+
+_EMPTY_HTML = "<html><body><p>Nenhum resultado</p></body></html>"
+
+
+# ---------------------------------------------------------------------------
+# buscar_diario_oficial
+# ---------------------------------------------------------------------------
+
+
+class TestBuscarDiarioOficial:
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_returns_parsed_publicacoes(self) -> None:
+        respx.get(DIARIO_OFICIAL_URL).mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "data": [
+                        {
+                            "NumeroPublicacao": 42,
+                            "DataPublicacao": "2024-03-15",
+                            "TipoAto": "Contratos",
+                            "Publicacao": "Contrato nº 001/2024",
+                        }
+                    ]
+                },
+            )
+        )
+        result = await client.buscar_diario_oficial(ano=2024)
+        assert len(result) == 1
+        assert result[0].numero_publicacao == 42
+        assert result[0].tipo_ato == "Contratos"
+        assert result[0].data_publicacao == "2024-03-15"
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_strips_html_from_publicacao(self) -> None:
+        respx.get(DIARIO_OFICIAL_URL).mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "data": [
+                        {
+                            "NumeroPublicacao": 1,
+                            "DataPublicacao": "2024-01-01",
+                            "TipoAto": "Atos e Normas",
+                            "Publicacao": "<b>Resolução</b> nº <i>001/2024</i>",
+                        }
+                    ]
+                },
+            )
+        )
+        result = await client.buscar_diario_oficial(ano=2024)
+        assert "<b>" not in result[0].publicacao
+        assert "<i>" not in result[0].publicacao
+        assert "Resolução" in result[0].publicacao
+        assert "001/2024" in result[0].publicacao
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_handles_flat_list_response(self) -> None:
+        respx.get(DIARIO_OFICIAL_URL).mock(
+            return_value=httpx.Response(
+                200,
+                json=[
+                    {
+                        "NumeroPublicacao": 7,
+                        "DataPublicacao": "2024-06-10",
+                        "TipoAto": "Licitações",
+                        "Publicacao": "Pregão Eletrônico nº 001/2024",
+                    }
+                ],
+            )
+        )
+        result = await client.buscar_diario_oficial(ano=2024)
+        assert len(result) == 1
+        assert result[0].numero_publicacao == 7
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_empty_data_envelope(self) -> None:
+        respx.get(DIARIO_OFICIAL_URL).mock(return_value=httpx.Response(200, json={"data": []}))
+        result = await client.buscar_diario_oficial(ano=2024)
+        assert result == []
+
+
+# ---------------------------------------------------------------------------
+# buscar_sessoes_plenarias (HTML scraping)
+# ---------------------------------------------------------------------------
+
+
+class TestBuscarSessoesPlenarias:
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_returns_parsed_sessoes(self) -> None:
+        respx.get(SESSOES_SEARCH_URL).mock(
+            return_value=httpx.Response(200, text=_SESSAO_HTML, headers=_HTML_HEADERS)
+        )
+        result = await client.buscar_sessoes_plenarias(tipo="sessoes")
+        assert len(result) == 1
+        assert result[0].titulo == "Sessão Ordinária nº 01/2024"
+        assert result[0].codigo == 42
+        assert result[0].tipo_sessao == "Ordinária"
+        assert result[0].data_sessao == "15/01/2024"
+        assert result[0].ano == 2024
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_doc_url_pautas(self) -> None:
+        respx.get(SESSOES_SEARCH_URL).mock(
+            return_value=httpx.Response(200, text=_SESSAO_HTML, headers=_HTML_HEADERS)
+        )
+        result = await client.buscar_sessoes_plenarias(tipo="pautas")
+        assert result[0].url_documento is not None
+        assert result[0].url_documento.endswith("/download")
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_doc_url_atas(self) -> None:
+        respx.get(SESSOES_SEARCH_URL).mock(
+            return_value=httpx.Response(200, text=_SESSAO_HTML, headers=_HTML_HEADERS)
+        )
+        result = await client.buscar_sessoes_plenarias(tipo="atas")
+        assert result[0].url_documento is not None
+        assert result[0].url_documento.endswith("/download")
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_doc_url_videos(self) -> None:
+        respx.get(SESSOES_SEARCH_URL).mock(
+            return_value=httpx.Response(200, text=_SESSAO_HTML, headers=_HTML_HEADERS)
+        )
+        result = await client.buscar_sessoes_plenarias(tipo="videos")
+        assert result[0].url_documento is not None
+        assert result[0].url_documento.endswith("/conteudo-original")
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_doc_url_sessoes_is_none(self) -> None:
+        respx.get(SESSOES_SEARCH_URL).mock(
+            return_value=httpx.Response(200, text=_SESSAO_HTML, headers=_HTML_HEADERS)
+        )
+        result = await client.buscar_sessoes_plenarias(tipo="sessoes")
+        assert result[0].url_documento is None
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_empty_html_returns_empty_list(self) -> None:
+        respx.get(SESSOES_SEARCH_URL).mock(
+            return_value=httpx.Response(200, text=_EMPTY_HTML, headers=_HTML_HEADERS)
+        )
+        result = await client.buscar_sessoes_plenarias(tipo="sessoes")
+        assert result == []
+
+
+# ---------------------------------------------------------------------------
+# buscar_pesquisa_integrada (HTML scraping)
+# ---------------------------------------------------------------------------
+
+
+class TestBuscarPesquisaIntegrada:
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_returns_parsed_resultados(self) -> None:
+        respx.get(SESSOES_SEARCH_URL).mock(
+            return_value=httpx.Response(200, text=_RESULTADO_HTML, headers=_HTML_HEADERS)
+        )
+        result = await client.buscar_pesquisa_integrada(slug="acordaos")
+        assert len(result) == 1
+        assert result[0].titulo == "Acórdão nº 1234/2024"
+        assert "Data da sessão plenária" in result[0].campos
+        assert result[0].campos["Data da sessão plenária"] == "20/03/2024"
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_fonte_campo_filtered_out(self) -> None:
+        respx.get(SESSOES_SEARCH_URL).mock(
+            return_value=httpx.Response(200, text=_RESULTADO_HTML, headers=_HTML_HEADERS)
+        )
+        result = await client.buscar_pesquisa_integrada(slug="acordaos")
+        assert "Fonte" not in result[0].campos
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_pdf_url_for_bases_pdf_download(self) -> None:
+        respx.get(SESSOES_SEARCH_URL).mock(
+            return_value=httpx.Response(200, text=_RESULTADO_HTML, headers=_HTML_HEADERS)
+        )
+        result = await client.buscar_pesquisa_integrada(slug="acordaos")
+        assert result[0].url_documento is not None
+        assert result[0].url_documento.endswith("/download")
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_conteudo_original_url_for_other_bases(self) -> None:
+        respx.get(SESSOES_SEARCH_URL).mock(
+            return_value=httpx.Response(200, text=_RESULTADO_HTML, headers=_HTML_HEADERS)
+        )
+        result = await client.buscar_pesquisa_integrada(slug="noticias-portal-internet")
+        assert result[0].url_documento is not None
+        assert result[0].url_documento.endswith("/conteudo-original")
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_empty_html_returns_empty_list(self) -> None:
+        respx.get(SESSOES_SEARCH_URL).mock(
+            return_value=httpx.Response(200, text=_EMPTY_HTML, headers=_HTML_HEADERS)
+        )
+        result = await client.buscar_pesquisa_integrada(slug="resolucoes")
+        assert result == []
+
+
+# ---------------------------------------------------------------------------
+# _parse_sessoes_html (pure function — unit tested directly)
+# ---------------------------------------------------------------------------
+
+
+class TestParseSessoesHtml:
+    def test_skips_card_without_titulo_anchor(self) -> None:
+        html = """
+        <div class="resultado-organico">
+          <h2 class="resultado-organico-titulo"><span>Sem link</span></h2>
+        </div>
+        """
+        result = client._parse_sessoes_html(html, tipo="sessoes")
+        assert result == []
+
+    def test_extracts_codigo_from_url(self) -> None:
+        html = """
+        <div class="resultado-organico">
+          <h2 class="resultado-organico-titulo">
+            <a class="titulo"
+               href="/pesquisaintegrada/sessoes/codigo/777/titulo">Título</a>
+          </h2>
+        </div>
+        """
+        result = client._parse_sessoes_html(html, tipo="sessoes")
+        assert result[0].codigo == 777
+
+    def test_strips_query_params_from_href(self) -> None:
+        html = """
+        <div class="resultado-organico">
+          <h2 class="resultado-organico-titulo">
+            <a class="titulo"
+               href="/pesquisaintegrada/sessoes/codigo/1/titulo?foo=bar">Título</a>
+          </h2>
+        </div>
+        """
+        result = client._parse_sessoes_html(html, tipo="sessoes")
+        assert "?" not in result[0].url_pagina
+
+    def test_removes_conteudo_original_suffix(self) -> None:
+        html = """
+        <div class="resultado-organico">
+          <h2 class="resultado-organico-titulo">
+            <a class="titulo"
+               href="/pesquisaintegrada/sessoes/codigo/1/titulo/conteudo-original">
+              Título
+            </a>
+          </h2>
+        </div>
+        """
+        result = client._parse_sessoes_html(html, tipo="sessoes")
+        assert not result[0].url_pagina.endswith("/conteudo-original")
+
+
+# ---------------------------------------------------------------------------
+# _parse_resultados_html (pure function — unit tested directly)
+# ---------------------------------------------------------------------------
+
+
+class TestParseResultadosHtml:
+    def test_skips_card_without_titulo_anchor(self) -> None:
+        html = """
+        <div class="resultado-organico">
+          <h2 class="resultado-organico-titulo"><span>Sem link</span></h2>
+        </div>
+        """
+        result = client._parse_resultados_html(html, slug="acordaos")
+        assert result == []
+
+    def test_extracts_campos_from_card(self) -> None:
+        html = """
+        <div class="resultado-organico">
+          <h2 class="resultado-organico-titulo">
+            <a class="titulo" href="/pesquisaintegrada/acordaos/codigo/1/titulo">
+              Acórdão nº 1/2024
+            </a>
+          </h2>
+          <div class="resultado-organico-campo">
+            <dfn class="resultado-organico-campo-nome">Data</dfn>
+            <span class="resultado-organico-campo-valor">01/01/2024</span>
+          </div>
+        </div>
+        """
+        result = client._parse_resultados_html(html, slug="acordaos")
+        assert len(result) == 1
+        assert "Data" in result[0].campos
+        assert result[0].campos["Data"] == "01/01/2024"
+
+    def test_filters_fonte_campo(self) -> None:
+        html = """
+        <div class="resultado-organico">
+          <h2 class="resultado-organico-titulo">
+            <a class="titulo" href="/pesquisaintegrada/acordaos/codigo/1/titulo">Título</a>
+          </h2>
+          <div class="resultado-organico-campo">
+            <dfn class="resultado-organico-campo-nome">Fonte</dfn>
+            <span class="resultado-organico-campo-valor">TCE-PA</span>
+          </div>
+        </div>
+        """
+        result = client._parse_resultados_html(html, slug="acordaos")
+        assert "Fonte" not in result[0].campos
+
+    def test_pdf_url_for_pdf_bases(self) -> None:
+        html = """
+        <div class="resultado-organico">
+          <h2 class="resultado-organico-titulo">
+            <a class="titulo" href="/pesquisaintegrada/acordaos/codigo/1/titulo">Título</a>
+          </h2>
+        </div>
+        """
+        result = client._parse_resultados_html(html, slug="acordaos")
+        assert result[0].url_documento is not None
+        assert result[0].url_documento.endswith("/download")
+
+    def test_conteudo_original_url_for_non_pdf_bases(self) -> None:
+        html = """
+        <div class="resultado-organico">
+          <h2 class="resultado-organico-titulo">
+            <a class="titulo" href="/pesquisaintegrada/noticias/codigo/1/titulo">Título</a>
+          </h2>
+        </div>
+        """
+        result = client._parse_resultados_html(html, slug="noticias-portal-internet")
+        assert result[0].url_documento is not None
+        assert result[0].url_documento.endswith("/conteudo-original")
+
+    def test_strips_query_params_from_href(self) -> None:
+        html = """
+        <div class="resultado-organico">
+          <h2 class="resultado-organico-titulo">
+            <a class="titulo"
+               href="/pesquisaintegrada/acordaos/codigo/1/titulo?q=teste">Título</a>
+          </h2>
+        </div>
+        """
+        result = client._parse_resultados_html(html, slug="acordaos")
+        assert "?" not in result[0].url_pagina
+
+    def test_truncates_long_campo_value(self) -> None:
+        long_value = "X" * 300
+        html = f"""
+        <div class="resultado-organico">
+          <h2 class="resultado-organico-titulo">
+            <a class="titulo" href="/pesquisaintegrada/acordaos/codigo/1/titulo">Título</a>
+          </h2>
+          <div class="resultado-organico-campo">
+            <dfn class="resultado-organico-campo-nome">Descrição</dfn>
+            <span class="resultado-organico-campo-valor">{long_value}</span>
+          </div>
+        </div>
+        """
+        result = client._parse_resultados_html(html, slug="acordaos")
+        assert len(result[0].campos["Descrição"]) == 200
+
+
+# ---------------------------------------------------------------------------
+# _build_query (pure function)
+# ---------------------------------------------------------------------------
+
+
+class TestBuildQuery:
+    def test_empty_returns_empty_string(self) -> None:
+        assert client._build_query("", None, None) == ""
+
+    def test_query_only(self) -> None:
+        assert client._build_query("licitação", None, None) == "licitação"
+
+    def test_ano_appended(self) -> None:
+        result = client._build_query("", 2024, None)
+        assert "ano:2024" in result
+
+    def test_mes_appended_zero_padded(self) -> None:
+        result = client._build_query("", None, 3)
+        assert "mes:03" in result
+
+    def test_all_params_combined(self) -> None:
+        result = client._build_query("contrato", 2024, 6)
+        assert "contrato" in result
+        assert "ano:2024" in result
+        assert "mes:06" in result
+
+    def test_no_query_with_ano(self) -> None:
+        result = client._build_query("", 2023, None)
+        assert result == "ano:2023"
+
+
+# ---------------------------------------------------------------------------
+# _strip_html (pure function)
+# ---------------------------------------------------------------------------
+
+
+class TestStripHtml:
+    def test_removes_tags(self) -> None:
+        assert client._strip_html("<b>Texto</b>") == "Texto"
+
+    def test_removes_nested_tags(self) -> None:
+        result = client._strip_html("<p><b>Texto</b><i>Extra</i></p>")
+        assert "Texto" in result
+        assert "Extra" in result
+        assert "<" not in result
+
+    def test_empty_string(self) -> None:
+        assert client._strip_html("") == ""
+
+    def test_no_tags(self) -> None:
+        assert client._strip_html("Texto simples") == "Texto simples"

--- a/tests/data/tce_pa/test_integration.py
+++ b/tests/data/tce_pa/test_integration.py
@@ -1,0 +1,169 @@
+"""Integration tests for the TCE-PA feature using fastmcp.Client."""
+
+import json
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastmcp import Client
+
+from mcp_brasil.data.tce_pa.schemas import DiarioOficial, ResultadoPesquisa, SessaoPlenaria
+from mcp_brasil.data.tce_pa.server import mcp
+
+CLIENT_MODULE = "mcp_brasil.data.tce_pa.client"
+
+
+class TestToolsRegistered:
+    @pytest.mark.asyncio
+    async def test_all_4_tools_registered(self) -> None:
+        async with Client(mcp) as c:
+            tool_list = await c.list_tools()
+            names = {t.name for t in tool_list}
+            expected = {
+                "buscar_diario_oficial_pa",
+                "buscar_sessoes_plenarias_pa",
+                "buscar_jurisprudencia_pa",
+                "buscar_conteudo_pa",
+            }
+            assert expected.issubset(names), f"Missing: {expected - names}"
+
+    @pytest.mark.asyncio
+    async def test_tools_have_docstrings(self) -> None:
+        async with Client(mcp) as c:
+            tool_list = await c.list_tools()
+            for tool in tool_list:
+                assert tool.description, f"Tool {tool.name} has no description"
+
+
+class TestResourcesRegistered:
+    @pytest.mark.asyncio
+    async def test_endpoints_resource_registered(self) -> None:
+        async with Client(mcp) as c:
+            resources = await c.list_resources()
+            uris = {str(r.uri) for r in resources}
+            assert "data://endpoints" in uris, f"URIs found: {uris}"
+
+    @pytest.mark.asyncio
+    async def test_endpoints_resource_content(self) -> None:
+        async with Client(mcp) as c:
+            content = await c.read_resource("data://endpoints")
+            text = content[0].text if isinstance(content, list) else str(content)
+            data = json.loads(text)
+            endpoints = [e["endpoint"] for e in data]
+            assert "/v1/diario_oficial" in endpoints
+            assert "/pesquisa/resultados" in endpoints
+
+    @pytest.mark.asyncio
+    async def test_endpoints_resource_has_all_bases(self) -> None:
+        async with Client(mcp) as c:
+            content = await c.read_resource("data://endpoints")
+            text = content[0].text if isinstance(content, list) else str(content)
+            assert "acordaos" in text
+            assert "resolucoes" in text
+            assert "prejulgados" in text
+            assert "noticias" in text
+            assert "sessoes-plenarias" in text
+
+
+class TestPromptsRegistered:
+    @pytest.mark.asyncio
+    async def test_all_4_prompts_registered(self) -> None:
+        async with Client(mcp) as c:
+            prompts = await c.list_prompts()
+            names = {p.name for p in prompts}
+            expected = {
+                "analisar_jurisprudencia_pa",
+                "analisar_diario_oficial_pa",
+                "analisar_sessoes_plenarias_pa",
+                "explorar_conteudo_pa",
+            }
+            assert expected.issubset(names), f"Missing: {expected - names}"
+
+
+class TestToolExecution:
+    @pytest.mark.asyncio
+    async def test_buscar_diario_oficial_pa_e2e(self) -> None:
+        mock_data = [
+            DiarioOficial(
+                numero_publicacao=1,
+                data_publicacao="2024-01-01",
+                tipo_ato="Contratos",
+                publicacao="Contrato teste",
+            )
+        ]
+        with patch(
+            f"{CLIENT_MODULE}.buscar_diario_oficial",
+            new_callable=AsyncMock,
+            return_value=mock_data,
+        ):
+            async with Client(mcp) as c:
+                result = await c.call_tool("buscar_diario_oficial_pa", {"ano": 2024})
+                assert "Contratos" in result.data
+
+    @pytest.mark.asyncio
+    async def test_buscar_diario_oficial_pa_empty_e2e(self) -> None:
+        with patch(
+            f"{CLIENT_MODULE}.buscar_diario_oficial",
+            new_callable=AsyncMock,
+            return_value=[],
+        ):
+            async with Client(mcp) as c:
+                result = await c.call_tool("buscar_diario_oficial_pa", {"ano": 2024})
+                assert "Nenhuma publicação encontrada" in result.data
+
+    @pytest.mark.asyncio
+    async def test_buscar_sessoes_plenarias_pa_e2e(self) -> None:
+        mock_data = [
+            SessaoPlenaria(
+                titulo="Sessão Ordinária nº 01/2024",
+                data_sessao="15/01/2024",
+                tipo_sessao="Ordinária",
+                ano=2024,
+                url_pagina="https://www.tcepa.tc.br/sessoes/codigo/1/titulo",
+            )
+        ]
+        with patch(
+            f"{CLIENT_MODULE}.buscar_sessoes_plenarias",
+            new_callable=AsyncMock,
+            return_value=mock_data,
+        ):
+            async with Client(mcp) as c:
+                result = await c.call_tool("buscar_sessoes_plenarias_pa", {"tipo": "sessoes"})
+                assert "Ordinária" in result.data
+
+    @pytest.mark.asyncio
+    async def test_buscar_jurisprudencia_pa_e2e(self) -> None:
+        mock_data = [
+            ResultadoPesquisa(
+                titulo="Acórdão nº 1/2024",
+                url_pagina="https://www.tcepa.tc.br/acordaos/codigo/1/titulo",
+                url_documento="https://www.tcepa.tc.br/acordaos/codigo/1/titulo/download",
+                campos={"Data da sessão plenária": "01/01/2024"},
+            )
+        ]
+        with patch(
+            f"{CLIENT_MODULE}.buscar_pesquisa_integrada",
+            new_callable=AsyncMock,
+            return_value=mock_data,
+        ):
+            async with Client(mcp) as c:
+                result = await c.call_tool("buscar_jurisprudencia_pa", {"base": "acordaos"})
+                assert "Acórdão" in result.data
+
+    @pytest.mark.asyncio
+    async def test_buscar_conteudo_pa_e2e(self) -> None:
+        mock_data = [
+            ResultadoPesquisa(
+                titulo="TCE-PA em ação",
+                url_pagina="https://www.tcepa.tc.br/noticias/codigo/1/titulo",
+                url_documento="https://www.tcepa.tc.br/noticias/codigo/1/titulo/conteudo-original",
+                campos={"Data de publicação": "01/04/2024"},
+            )
+        ]
+        with patch(
+            f"{CLIENT_MODULE}.buscar_pesquisa_integrada",
+            new_callable=AsyncMock,
+            return_value=mock_data,
+        ):
+            async with Client(mcp) as c:
+                result = await c.call_tool("buscar_conteudo_pa", {"base": "noticias"})
+                assert "TCE-PA em ação" in result.data

--- a/tests/data/tce_pa/test_tools.py
+++ b/tests/data/tce_pa/test_tools.py
@@ -1,0 +1,317 @@
+"""Tests for the TCE-PA tool functions."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from mcp_brasil.data.tce_pa import tools
+from mcp_brasil.data.tce_pa.schemas import DiarioOficial, ResultadoPesquisa, SessaoPlenaria
+
+CLIENT_MODULE = "mcp_brasil.data.tce_pa.client"
+
+
+def _mock_ctx() -> MagicMock:
+    ctx = MagicMock()
+    ctx.info = AsyncMock()
+    ctx.warning = AsyncMock()
+    return ctx
+
+
+# ---------------------------------------------------------------------------
+# buscar_diario_oficial_pa
+# ---------------------------------------------------------------------------
+
+
+class TestBuscarDiarioOficialPa:
+    @pytest.mark.asyncio
+    async def test_formats_results(self) -> None:
+        mock_data = [
+            DiarioOficial(
+                numero_publicacao=42,
+                data_publicacao="2024-03-15",
+                tipo_ato="Contratos",
+                publicacao="Contrato nº 001/2024 firmado entre TCE-PA e Empresa X",
+            )
+        ]
+        ctx = _mock_ctx()
+        with patch(
+            f"{CLIENT_MODULE}.buscar_diario_oficial",
+            new_callable=AsyncMock,
+            return_value=mock_data,
+        ):
+            result = await tools.buscar_diario_oficial_pa(ctx, ano=2024)
+        assert "42" in result
+        assert "2024-03-15" in result
+        assert "Contratos" in result
+        assert "Contrato nº 001/2024" in result
+
+    @pytest.mark.asyncio
+    async def test_empty_results(self) -> None:
+        ctx = _mock_ctx()
+        with patch(
+            f"{CLIENT_MODULE}.buscar_diario_oficial",
+            new_callable=AsyncMock,
+            return_value=[],
+        ):
+            result = await tools.buscar_diario_oficial_pa(ctx, ano=2024)
+        assert "Nenhuma publicação encontrada" in result
+
+    @pytest.mark.asyncio
+    async def test_truncates_long_publicacao(self) -> None:
+        long_text = "A" * 200
+        mock_data = [
+            DiarioOficial(
+                numero_publicacao=1,
+                data_publicacao="2024-01-01",
+                tipo_ato="Atos e Normas",
+                publicacao=long_text,
+            )
+        ]
+        ctx = _mock_ctx()
+        with patch(
+            f"{CLIENT_MODULE}.buscar_diario_oficial",
+            new_callable=AsyncMock,
+            return_value=mock_data,
+        ):
+            result = await tools.buscar_diario_oficial_pa(ctx, ano=2024)
+        assert "..." in result
+
+    @pytest.mark.asyncio
+    async def test_handles_none_fields(self) -> None:
+        mock_data = [DiarioOficial()]
+        ctx = _mock_ctx()
+        with patch(
+            f"{CLIENT_MODULE}.buscar_diario_oficial",
+            new_callable=AsyncMock,
+            return_value=mock_data,
+        ):
+            result = await tools.buscar_diario_oficial_pa(ctx, ano=2024)
+        assert "—" in result
+
+
+# ---------------------------------------------------------------------------
+# buscar_sessoes_plenarias_pa
+# ---------------------------------------------------------------------------
+
+
+class TestBuscarSessoesPlenariasPa:
+    @pytest.mark.asyncio
+    async def test_formats_sessoes(self) -> None:
+        mock_data = [
+            SessaoPlenaria(
+                codigo=10,
+                titulo="Sessão Ordinária nº 01/2024",
+                data_sessao="15/01/2024",
+                tipo_sessao="Ordinária",
+                ano=2024,
+                url_pagina="https://www.tcepa.tc.br/sessoes/codigo/10/titulo",
+            )
+        ]
+        ctx = _mock_ctx()
+        with patch(
+            f"{CLIENT_MODULE}.buscar_sessoes_plenarias",
+            new_callable=AsyncMock,
+            return_value=mock_data,
+        ):
+            result = await tools.buscar_sessoes_plenarias_pa(ctx, tipo="sessoes")
+        assert "15/01/2024" in result
+        assert "Ordinária" in result
+        assert "2024" in result
+
+    @pytest.mark.asyncio
+    async def test_formats_pautas_with_pdf_col(self) -> None:
+        mock_data = [
+            SessaoPlenaria(
+                titulo="Pauta nº 01/2024",
+                data_sessao="15/01/2024",
+                tipo_sessao="Ordinária",
+                url_documento="https://www.tcepa.tc.br/pautas/codigo/5/titulo/download",
+            )
+        ]
+        ctx = _mock_ctx()
+        with patch(
+            f"{CLIENT_MODULE}.buscar_sessoes_plenarias",
+            new_callable=AsyncMock,
+            return_value=mock_data,
+        ):
+            result = await tools.buscar_sessoes_plenarias_pa(ctx, tipo="pautas")
+        assert "Download PDF" in result
+
+    @pytest.mark.asyncio
+    async def test_formats_videos_with_youtube_col(self) -> None:
+        mock_data = [
+            SessaoPlenaria(
+                titulo="Vídeo Sessão Ordinária 01/2024",
+                data_sessao="15/01/2024",
+                tipo_sessao="Ordinária",
+                url_documento="https://youtu.be/abc123",
+            )
+        ]
+        ctx = _mock_ctx()
+        with patch(
+            f"{CLIENT_MODULE}.buscar_sessoes_plenarias",
+            new_callable=AsyncMock,
+            return_value=mock_data,
+        ):
+            result = await tools.buscar_sessoes_plenarias_pa(ctx, tipo="videos")
+        assert "Vídeo (YouTube)" in result
+
+    @pytest.mark.asyncio
+    async def test_invalid_tipo_returns_error(self) -> None:
+        ctx = _mock_ctx()
+        result = await tools.buscar_sessoes_plenarias_pa(ctx, tipo="invalido")
+        assert "Tipo inválido" in result
+        assert "invalido" in result
+
+    @pytest.mark.asyncio
+    async def test_empty_results(self) -> None:
+        ctx = _mock_ctx()
+        with patch(
+            f"{CLIENT_MODULE}.buscar_sessoes_plenarias",
+            new_callable=AsyncMock,
+            return_value=[],
+        ):
+            result = await tools.buscar_sessoes_plenarias_pa(ctx, tipo="sessoes")
+        assert "Nenhuma sessão encontrada" in result
+
+
+# ---------------------------------------------------------------------------
+# buscar_jurisprudencia_pa
+# ---------------------------------------------------------------------------
+
+
+class TestBuscarJurisprudenciaPa:
+    @pytest.mark.asyncio
+    async def test_formats_acordaos(self) -> None:
+        mock_data = [
+            ResultadoPesquisa(
+                titulo="Acórdão nº 1234/2024",
+                url_pagina="https://www.tcepa.tc.br/acordaos/codigo/99/titulo",
+                url_documento="https://www.tcepa.tc.br/acordaos/codigo/99/titulo/download",
+                campos={"Data da sessão plenária": "20/03/2024", "Decisões": "Aprovado"},
+            )
+        ]
+        ctx = _mock_ctx()
+        with patch(
+            f"{CLIENT_MODULE}.buscar_pesquisa_integrada",
+            new_callable=AsyncMock,
+            return_value=mock_data,
+        ):
+            result = await tools.buscar_jurisprudencia_pa(ctx, base="acordaos")
+        assert "Acórdão nº 1234/2024" in result
+        assert "20/03/2024" in result
+        assert "/download" in result
+
+    @pytest.mark.asyncio
+    async def test_invalid_base_returns_error(self) -> None:
+        ctx = _mock_ctx()
+        result = await tools.buscar_jurisprudencia_pa(ctx, base="invalida")
+        assert "Base inválida" in result
+        assert "invalida" in result
+
+    @pytest.mark.asyncio
+    async def test_empty_results(self) -> None:
+        ctx = _mock_ctx()
+        with patch(
+            f"{CLIENT_MODULE}.buscar_pesquisa_integrada",
+            new_callable=AsyncMock,
+            return_value=[],
+        ):
+            result = await tools.buscar_jurisprudencia_pa(ctx, base="resolucoes")
+        assert "Nenhum resultado encontrado" in result
+
+    @pytest.mark.asyncio
+    async def test_all_valid_bases_accepted(self) -> None:
+        bases = [
+            "acordaos",
+            "acordaos-virtual",
+            "resolucoes",
+            "portarias",
+            "atos",
+            "informativos",
+            "prejulgados",
+        ]
+        ctx = _mock_ctx()
+        for base in bases:
+            with patch(
+                f"{CLIENT_MODULE}.buscar_pesquisa_integrada",
+                new_callable=AsyncMock,
+                return_value=[],
+            ):
+                result = await tools.buscar_jurisprudencia_pa(ctx, base=base)
+            assert "Base inválida" not in result
+
+
+# ---------------------------------------------------------------------------
+# buscar_conteudo_pa
+# ---------------------------------------------------------------------------
+
+
+class TestBuscarConteudoPa:
+    @pytest.mark.asyncio
+    async def test_formats_noticias(self) -> None:
+        mock_data = [
+            ResultadoPesquisa(
+                titulo="TCE-PA lança sistema de fiscalização",
+                url_pagina="https://www.tcepa.tc.br/noticias/codigo/55/titulo",
+                url_documento="https://www.tcepa.tc.br/noticias/codigo/55/conteudo-original",
+                campos={"Data de publicação": "10/04/2024", "Resumo": "O TCE-PA anunciou..."},
+            )
+        ]
+        ctx = _mock_ctx()
+        with patch(
+            f"{CLIENT_MODULE}.buscar_pesquisa_integrada",
+            new_callable=AsyncMock,
+            return_value=mock_data,
+        ):
+            result = await tools.buscar_conteudo_pa(ctx, base="noticias")
+        assert "TCE-PA lança sistema" in result
+        assert "10/04/2024" in result
+
+    @pytest.mark.asyncio
+    async def test_youtube_col_label(self) -> None:
+        mock_data = [
+            ResultadoPesquisa(
+                titulo="Sessão ao vivo",
+                url_documento="https://youtu.be/xyz",
+                campos={},
+            )
+        ]
+        ctx = _mock_ctx()
+        with patch(
+            f"{CLIENT_MODULE}.buscar_pesquisa_integrada",
+            new_callable=AsyncMock,
+            return_value=mock_data,
+        ):
+            result = await tools.buscar_conteudo_pa(ctx, base="youtube")
+        assert "Vídeo (YouTube)" in result
+
+    @pytest.mark.asyncio
+    async def test_invalid_base_returns_error(self) -> None:
+        ctx = _mock_ctx()
+        result = await tools.buscar_conteudo_pa(ctx, base="invalida")
+        assert "Base inválida" in result
+
+    @pytest.mark.asyncio
+    async def test_empty_results(self) -> None:
+        ctx = _mock_ctx()
+        with patch(
+            f"{CLIENT_MODULE}.buscar_pesquisa_integrada",
+            new_callable=AsyncMock,
+            return_value=[],
+        ):
+            result = await tools.buscar_conteudo_pa(ctx, base="noticias")
+        assert "Nenhum resultado encontrado" in result
+
+    @pytest.mark.asyncio
+    async def test_all_valid_bases_accepted(self) -> None:
+        bases = ["noticias", "acervo", "educacao", "youtube", "imagens"]
+        ctx = _mock_ctx()
+        for base in bases:
+            with patch(
+                f"{CLIENT_MODULE}.buscar_pesquisa_integrada",
+                new_callable=AsyncMock,
+                return_value=[],
+            ):
+                result = await tools.buscar_conteudo_pa(ctx, base=base)
+            assert "Base inválida" not in result


### PR DESCRIPTION
## O que mudou

Adiciona o módulo `tce_pa` com 4 tools cobrindo o Tribunal de Contas do Estado do Pará:

- **`buscar_diario_oficial_pa`** — publicações do Diário Oficial do TCE-PA com filtros por ano, mês, tipo de ato e número
- **`buscar_sessoes_plenarias_pa`** — sessões, pautas, atas e vídeos do plenário
- **`buscar_jurisprudencia_pa`** — acórdãos, resoluções, portarias e prejulgados com links para PDF
- **`buscar_conteudo_pa`** — busca geral em notícias, licitações, concursos e outros conteúdos informativos

## Por quê

TCE-PA não tinha representação no projeto. A API de Dados Abertos e a Pesquisa Integrada do TCE-PA expõem dados relevantes (Diário Oficial, jurisprudência, sessões) que passam a ser acessíveis via MCP.

## Testes

Suite completa adicionada em `tests/data/tce_pa/`:

- **`test_tools.py`** — mock do client, testa lógica de formatação e validação
- **`test_client.py`** — mock HTTP com respx, testa parsing do HTML
- **`test_integration.py`** — e2e com `fastmcp.Client`

**65 testes, todos passando.** `make ci` (lint + mypy strict + pytest) passou sem erros.

## README

Contadores atualizados: `41 → 42 features`, `363 → 367 tools`. `tce_pa` adicionado na tabela de Transparência e Fiscalização.