### PR TITLE
feat/fix: server JSON coercion + siscomex NCM + comexstat (closes #8, #13)

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,11 +9,11 @@
 
 [![License: MIT (code)](https://img.shields.io/badge/code-MIT-yellow.svg)](LICENSE) [![Sources: see SOURCES.md](https://img.shields.io/badge/data-see%20SOURCES.md-blue)](SOURCES.md) [![AUP](https://img.shields.io/badge/use-ACCEPTABLE__USE.md-orange)](ACCEPTABLE_USE.md)
 
-533 tools · 131 resources · 102 prompts · 70 features · 15 áreas temáticas
+539 tools · 131 resources · 102 prompts · 72 features · 16 áreas temáticas
 
 Conecte AI agents (Claude, GPT, Copilot, etc.) a dados governamentais do Brasil — economia, legislação, transparência, judiciário, eleições, meio ambiente, saúde, educação, segurança pública, fiscal subnacional, aviação e mais.
 
-**66 APIs não requerem chave** · 4 usam chaves gratuitas (cadastro em 1 min)
+**68 APIs não requerem chave** · 4 usam chaves gratuitas (cadastro em 1 min)
 
 [Quick Start](#quick-start) · [Fontes de dados](#fontes-de-dados) · [Documentação](#documentação) · [Desenvolvimento](#desenvolvimento)
 
@@ -128,6 +128,13 @@ Conecte o server e faça perguntas em linguagem natural:
 | `bcb_olinda` | Banco Central — PTAX (câmbio oficial), Expectativas Focus, taxas de juros bancárias | 8 |
 | `bndes` | BNDES — operações de financiamento, desembolsos, instituições credenciadas | 4 |
 | `ipeadata` | IPEADATA/Ipea — séries macro, regionais e sociais históricas (OData) | 5 |
+
+### Comércio Exterior
+
+| Feature | Fonte | Tools |
+|---------|-------|:-----:|
+| `comexstat` | ComexStat MDIC — exportações e importações brasileiras por NCM, país e período (desde 1997) | 4 |
+| `siscomex` | Portal Único Siscomex — Nomenclatura Comum do Mercosul (NCM) oficial com rastreamento de vigência | 2 |
 
 ### Geografia e Estatística
 
@@ -324,7 +331,7 @@ META_ACCESS_TOKEN=seu-token
 |--------|-----------|
 | [Quick Start](docs/guide/quickstart.md) | Instalação e configuração em 2 minutos |
 | [Arquitetura](docs/concepts/architecture.md) | Como o projeto funciona por dentro |
-| [Catálogo de Features](docs/reference/features.md) | Todas as 69 features e 525 tools |
+| [Catálogo de Features](docs/reference/features.md) | Todas as 72 features e 539 tools |
 | [Datasets locais (DuckDB)](docs/guide/datasets.md) | SIAPA + TSE 2014-2024 via SQL embedded |
 | [Smart Tools](docs/reference/smart-tools.md) | Meta-tools: planner, batch, discovery |
 | [Adicionando Features](docs/guide/adding-features.md) | Guia para contribuir com novas APIs |
@@ -360,7 +367,7 @@ src/mcp_brasil/
 ├── server.py              # Auto-registry (nunca editado manualmente)
 ├── _shared/               # Utilitários compartilhados
 │   └── datasets/          # Infra DuckDB local
-├── data/                  # 51 features — REST passthrough
+├── data/                  # 53 features — REST passthrough
 │   ├── ibge/
 │   │   ├── __init__.py    # FEATURE_META
 │   │   ├── server.py      # FastMCP instance

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,7 @@ dependencies = [
     "lxml>=5.0",
     "duckdb>=1.1",
     "openpyxl>=3.1.5",
+    "curl-cffi>=0.15.0",
 ]
 
 [project.optional-dependencies]

--- a/src/mcp_brasil/_shared/batch.py
+++ b/src/mcp_brasil/_shared/batch.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import asyncio
 import importlib
 import inspect
+import json
 import logging
 import pkgutil
 from typing import TYPE_CHECKING, Any
@@ -89,6 +90,15 @@ async def execute_batch(
     async def _run_one(q: dict[str, Any]) -> tuple[str, str]:
         tool_name = q.get("tool", "")
         args = q.get("args", {})
+
+        if isinstance(args, str):
+            try:
+                args = json.loads(args)
+            except json.JSONDecodeError as exc:
+                return tool_name, f"'args' não é JSON válido: {exc}"
+        if not isinstance(args, dict):
+            return tool_name, f"'args' deve ser um objeto JSON, recebido: {type(args).__name__}"
+
         fn = _dispatch.get(tool_name)
 
         if fn is None:

--- a/src/mcp_brasil/data/comexstat/__init__.py
+++ b/src/mcp_brasil/data/comexstat/__init__.py
@@ -1,0 +1,15 @@
+"""Feature ComexStat — Brazilian foreign trade statistics (MDIC)."""
+
+from mcp_brasil._shared.feature import FeatureMeta
+
+FEATURE_META = FeatureMeta(
+    name="comexstat",
+    description=(
+        "ComexStat MDIC: estatísticas de exportações e importações brasileiras — "
+        "dados mensais desde 1997 por NCM, país e período, sem autenticação."
+    ),
+    version="0.1.0",
+    api_base="https://api-comexstat.mdic.gov.br",
+    requires_auth=False,
+    tags=["comercio-exterior", "exportacao", "importacao", "mdic", "comexstat"],
+)

--- a/src/mcp_brasil/data/comexstat/client.py
+++ b/src/mcp_brasil/data/comexstat/client.py
@@ -1,0 +1,172 @@
+"""HTTP client for the ComexStat feature.
+
+Endpoints:
+    - POST /general/query              → _query (export/import data)
+    - GET  /general/filters/country   → listar_paises
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+from mcp_brasil._shared.http_client import http_get, http_post
+from mcp_brasil._shared.rate_limiter import RateLimiter
+
+from .constants import COUNTRY_URL, FLOW_EXPORT, FLOW_IMPORT, METRIC_FOB, METRIC_KG, QUERY_URL
+from .schemas import BalancaItem, ComexItem, PaisItem
+
+_rate_limiter = RateLimiter(max_requests=30, period=60.0)
+
+
+def _build_periodo(row: dict[str, Any], month_detail: bool) -> str:
+    """Extract a YYYY-MM or YYYY period string from a ComexStat row."""
+    if month_detail:
+        ano_mes = str(row.get("coAnoMes", ""))
+        if len(ano_mes) == 6:
+            return f"{ano_mes[:4]}-{ano_mes[4:]}"
+        return ano_mes
+    return str(row.get("coAno", ""))
+
+
+async def _query(
+    flow: str,
+    period_from: str,
+    period_to: str,
+    details: list[str],
+    filters: list[dict[str, Any]],
+    metrics: list[str],
+    month_detail: bool,
+) -> list[dict[str, Any]]:
+    """POST to ComexStat query endpoint and return the data list."""
+    body: dict[str, Any] = {
+        "flow": flow,
+        "period": {"from": period_from, "to": period_to},
+        "details": details,
+        "filters": filters,
+        "metrics": metrics,
+        "monthDetail": month_detail,
+    }
+    async with _rate_limiter:
+        raw: dict[str, Any] = await http_post(QUERY_URL, json_body=body)
+    data: dict[str, Any] = raw.get("data") or {}
+    return list(data.get("list") or [])
+
+
+def _rows_to_comex(rows: list[dict[str, Any]], month_detail: bool) -> list[ComexItem]:
+    return [
+        ComexItem(
+            periodo=_build_periodo(row, month_detail),
+            pais=row.get("noPaisPt") or row.get("noPais") or None,
+            ncm=row.get("coNcm") or None,
+            fob_usd=float(row.get("metricFOB") or 0),
+            kg_liquido=float(row.get("metricKG") or 0),
+        )
+        for row in rows
+    ]
+
+
+async def consultar_exportacoes(
+    periodo_inicio: str,
+    periodo_fim: str,
+    ncm: str | None = None,
+    pais: str | None = None,
+    detalhar_por_mes: bool = False,
+) -> list[ComexItem]:
+    """Fetch Brazilian export statistics from ComexStat."""
+    details: list[str] = []
+    filters: list[dict[str, Any]] = []
+    if ncm:
+        details.append("ncm")
+        filters.append({"filter": "ncm", "values": [ncm]})
+    if pais:
+        details.append("country")
+        filters.append({"filter": "country", "values": [pais]})
+    rows = await _query(
+        FLOW_EXPORT,
+        periodo_inicio,
+        periodo_fim,
+        details,
+        filters,
+        [METRIC_FOB, METRIC_KG],
+        detalhar_por_mes,
+    )
+    return _rows_to_comex(rows, detalhar_por_mes)
+
+
+async def consultar_importacoes(
+    periodo_inicio: str,
+    periodo_fim: str,
+    ncm: str | None = None,
+    pais: str | None = None,
+    detalhar_por_mes: bool = False,
+) -> list[ComexItem]:
+    """Fetch Brazilian import statistics from ComexStat."""
+    details: list[str] = []
+    filters: list[dict[str, Any]] = []
+    if ncm:
+        details.append("ncm")
+        filters.append({"filter": "ncm", "values": [ncm]})
+    if pais:
+        details.append("country")
+        filters.append({"filter": "country", "values": [pais]})
+    rows = await _query(
+        FLOW_IMPORT,
+        periodo_inicio,
+        periodo_fim,
+        details,
+        filters,
+        [METRIC_FOB, METRIC_KG],
+        detalhar_por_mes,
+    )
+    return _rows_to_comex(rows, detalhar_por_mes)
+
+
+async def balanca_comercial(
+    periodo_inicio: str,
+    periodo_fim: str,
+    ncm: str | None = None,
+) -> list[BalancaItem]:
+    """Compute trade balance (exports FOB - imports FOB) per month."""
+    filters: list[dict[str, Any]] = []
+    if ncm:
+        filters.append({"filter": "ncm", "values": [ncm]})
+    exp_rows, imp_rows = await asyncio.gather(
+        _query(FLOW_EXPORT, periodo_inicio, periodo_fim, [], filters, [METRIC_FOB], True),
+        _query(FLOW_IMPORT, periodo_inicio, periodo_fim, [], filters, [METRIC_FOB], True),
+    )
+
+    exp_by: dict[str, float] = {}
+    for row in exp_rows:
+        p = _build_periodo(row, True)
+        exp_by[p] = exp_by.get(p, 0.0) + float(row.get("metricFOB") or 0)
+
+    imp_by: dict[str, float] = {}
+    for row in imp_rows:
+        p = _build_periodo(row, True)
+        imp_by[p] = imp_by.get(p, 0.0) + float(row.get("metricFOB") or 0)
+
+    all_periods = sorted(set(exp_by) | set(imp_by))
+    return [
+        BalancaItem(
+            periodo=p,
+            exportacoes_fob=exp_by.get(p, 0.0),
+            importacoes_fob=imp_by.get(p, 0.0),
+            saldo_fob=exp_by.get(p, 0.0) - imp_by.get(p, 0.0),
+        )
+        for p in all_periods
+    ]
+
+
+async def listar_paises() -> list[PaisItem]:
+    """Fetch available countries from ComexStat filters."""
+    async with _rate_limiter:
+        raw: dict[str, Any] = await http_get(COUNTRY_URL)
+    items: list[dict[str, Any]] = raw.get("data", {}).get("list", [])
+    return [
+        PaisItem(
+            id=str(item.get("id_country", "")),
+            nome=item.get("no_country_pt") or item.get("no_country_en", ""),
+        )
+        for item in items
+    ]

--- a/src/mcp_brasil/data/comexstat/client.py
+++ b/src/mcp_brasil/data/comexstat/client.py
@@ -1,7 +1,7 @@
 """HTTP client for the ComexStat feature.
 
 Endpoints:
-    - POST /general/query              → _query (export/import data)
+    - POST /general              → _query (export/import data)
     - GET  /general/filters/country   → listar_paises
 """
 
@@ -10,10 +10,20 @@ from __future__ import annotations
 import asyncio
 from typing import Any
 
-from mcp_brasil._shared.http_client import http_get, http_post
+from curl_cffi.requests import AsyncSession
+
+from mcp_brasil._shared.http_client import http_get
 from mcp_brasil._shared.rate_limiter import RateLimiter
 
-from .constants import COUNTRY_URL, FLOW_EXPORT, FLOW_IMPORT, METRIC_FOB, METRIC_KG, QUERY_URL
+from .constants import (
+    COUNTRY_URL,
+    FLOW_EXPORT,
+    FLOW_IMPORT,
+    METRIC_FOB,
+    METRIC_KG,
+    QUERY_URL,
+    REQUEST_HEADERS,
+)
 from .schemas import BalancaItem, ComexItem, PaisItem
 
 _rate_limiter = RateLimiter(max_requests=30, period=60.0)
@@ -21,12 +31,11 @@ _rate_limiter = RateLimiter(max_requests=30, period=60.0)
 
 def _build_periodo(row: dict[str, Any], month_detail: bool) -> str:
     """Extract a YYYY-MM or YYYY period string from a ComexStat row."""
+    year = str(row.get("year", ""))
     if month_detail:
-        ano_mes = str(row.get("coAnoMes", ""))
-        if len(ano_mes) == 6:
-            return f"{ano_mes[:4]}-{ano_mes[4:]}"
-        return ano_mes
-    return str(row.get("coAno", ""))
+        month = str(row.get("monthNumber", "")).zfill(2)
+        return f"{year}-{month}" if year else ""
+    return year
 
 
 async def _query(
@@ -38,7 +47,12 @@ async def _query(
     metrics: list[str],
     month_detail: bool,
 ) -> list[dict[str, Any]]:
-    """POST to ComexStat query endpoint and return the data list."""
+    """POST to ComexStat query endpoint and return the data list.
+
+    Uses curl_cffi to impersonate Chrome TLS fingerprint, bypassing
+    Cloudflare WAF which blocks non-browser TLS on POST /general.
+    Retries once after 12s on HTTP 429 (API rate limit window is 10s).
+    """
     body: dict[str, Any] = {
         "flow": flow,
         "period": {"from": period_from, "to": period_to},
@@ -47,8 +61,20 @@ async def _query(
         "metrics": metrics,
         "monthDetail": month_detail,
     }
-    async with _rate_limiter:
-        raw: dict[str, Any] = await http_post(QUERY_URL, json_body=body)
+    async with _rate_limiter, AsyncSession(impersonate="chrome124") as session:
+        for attempt in range(2):
+            response = await session.post(
+                QUERY_URL,
+                json=body,
+                headers=REQUEST_HEADERS,
+                timeout=30,
+            )
+            if response.status_code == 429 and attempt == 0:
+                await asyncio.sleep(12)
+                continue
+            response.raise_for_status()
+            break
+        raw: dict[str, Any] = response.json()
     data: dict[str, Any] = raw.get("data") or {}
     return list(data.get("list") or [])
 
@@ -57,8 +83,8 @@ def _rows_to_comex(rows: list[dict[str, Any]], month_detail: bool) -> list[Comex
     return [
         ComexItem(
             periodo=_build_periodo(row, month_detail),
-            pais=row.get("noPaisPt") or row.get("noPais") or None,
-            ncm=row.get("coNcm") or None,
+            pais=row.get("country") or None,
+            ncm=row.get("ncm") or None,
             fob_usd=float(row.get("metricFOB") or 0),
             kg_liquido=float(row.get("metricKG") or 0),
         )
@@ -127,13 +153,17 @@ async def balanca_comercial(
     periodo_fim: str,
     ncm: str | None = None,
 ) -> list[BalancaItem]:
-    """Compute trade balance (exports FOB - imports FOB) per month."""
+    """Compute trade balance (exports FOB - imports FOB) per period."""
     filters: list[dict[str, Any]] = []
     if ncm:
         filters.append({"filter": "ncm", "values": [ncm]})
-    exp_rows, imp_rows = await asyncio.gather(
-        _query(FLOW_EXPORT, periodo_inicio, periodo_fim, [], filters, [METRIC_FOB], True),
-        _query(FLOW_IMPORT, periodo_inicio, periodo_fim, [], filters, [METRIC_FOB], True),
+    # Sequential with delay — concurrent POSTs trigger API 429 rate limit
+    exp_rows = await _query(
+        FLOW_EXPORT, periodo_inicio, periodo_fim, [], filters, [METRIC_FOB], True
+    )
+    await asyncio.sleep(3)
+    imp_rows = await _query(
+        FLOW_IMPORT, periodo_inicio, periodo_fim, [], filters, [METRIC_FOB], True
     )
 
     exp_by: dict[str, float] = {}
@@ -161,12 +191,14 @@ async def balanca_comercial(
 async def listar_paises() -> list[PaisItem]:
     """Fetch available countries from ComexStat filters."""
     async with _rate_limiter:
-        raw: dict[str, Any] = await http_get(COUNTRY_URL)
-    items: list[dict[str, Any]] = raw.get("data", {}).get("list", [])
+        raw: dict[str, Any] = await http_get(COUNTRY_URL, headers=REQUEST_HEADERS)
+    # API returns {"data": [[{id, text}, ...]]} — outer list wraps one inner list
+    data_raw: list[Any] = raw.get("data") or []
+    items: list[dict[str, Any]] = data_raw[0] if data_raw else []
     return [
         PaisItem(
-            id=str(item.get("id_country", "")),
-            nome=item.get("no_country_pt") or item.get("no_country_en", ""),
+            id=str(item.get("id", "")),
+            nome=item.get("text", ""),
         )
         for item in items
     ]

--- a/src/mcp_brasil/data/comexstat/constants.py
+++ b/src/mcp_brasil/data/comexstat/constants.py
@@ -1,0 +1,11 @@
+"""Constants for the ComexStat feature."""
+
+BASE_URL = "https://api-comexstat.mdic.gov.br"
+QUERY_URL = f"{BASE_URL}/general/query"
+COUNTRY_URL = f"{BASE_URL}/general/filters/country"
+
+FLOW_EXPORT = "export"
+FLOW_IMPORT = "import"
+
+METRIC_FOB = "metricFOB"
+METRIC_KG = "metricKG"

--- a/src/mcp_brasil/data/comexstat/constants.py
+++ b/src/mcp_brasil/data/comexstat/constants.py
@@ -1,7 +1,7 @@
 """Constants for the ComexStat feature."""
 
 BASE_URL = "https://api-comexstat.mdic.gov.br"
-QUERY_URL = f"{BASE_URL}/general/query"
+QUERY_URL = f"{BASE_URL}/general"
 COUNTRY_URL = f"{BASE_URL}/general/filters/country"
 
 FLOW_EXPORT = "export"
@@ -9,3 +9,15 @@ FLOW_IMPORT = "import"
 
 METRIC_FOB = "metricFOB"
 METRIC_KG = "metricKG"
+
+# Cloudflare on api-comexstat.mdic.gov.br blocks non-browser UAs
+REQUEST_HEADERS: dict[str, str] = {
+    "User-Agent": (
+        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
+        "AppleWebKit/537.36 (KHTML, like Gecko) "
+        "Chrome/124.0.0.0 Safari/537.36"
+    ),
+    "Accept": "application/json, text/plain, */*",
+    "Origin": "https://comexstat.mdic.gov.br",
+    "Referer": "https://comexstat.mdic.gov.br/",
+}

--- a/src/mcp_brasil/data/comexstat/schemas.py
+++ b/src/mcp_brasil/data/comexstat/schemas.py
@@ -1,0 +1,31 @@
+"""Pydantic schemas for the ComexStat feature."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel
+
+
+class ComexItem(BaseModel):
+    """Single trade flow record from ComexStat."""
+
+    periodo: str
+    pais: str | None = None
+    ncm: str | None = None
+    fob_usd: float
+    kg_liquido: float
+
+
+class BalancaItem(BaseModel):
+    """Trade balance record for a period."""
+
+    periodo: str
+    exportacoes_fob: float
+    importacoes_fob: float
+    saldo_fob: float
+
+
+class PaisItem(BaseModel):
+    """Country entry from ComexStat filters."""
+
+    id: str
+    nome: str

--- a/src/mcp_brasil/data/comexstat/server.py
+++ b/src/mcp_brasil/data/comexstat/server.py
@@ -1,0 +1,16 @@
+"""ComexStat feature server — registers tools.
+
+This file only registers components. Zero business logic (ADR-001 rule #4).
+"""
+
+from fastmcp import FastMCP
+
+from .tools import balanca_comercial, consultar_exportacoes, consultar_importacoes, listar_paises
+
+mcp = FastMCP("mcp-brasil-comexstat")
+
+# Tools (4)
+mcp.tool(consultar_exportacoes, tags={"exportacao", "comercio-exterior", "comexstat"})
+mcp.tool(consultar_importacoes, tags={"importacao", "comercio-exterior", "comexstat"})
+mcp.tool(balanca_comercial, tags={"balanca", "comercio-exterior", "comexstat"})
+mcp.tool(listar_paises, tags={"paises", "comercio-exterior", "comexstat"})

--- a/src/mcp_brasil/data/comexstat/tools.py
+++ b/src/mcp_brasil/data/comexstat/tools.py
@@ -1,0 +1,178 @@
+"""Tool functions for the ComexStat feature.
+
+Rules (ADR-001):
+    - tools.py NEVER makes HTTP directly — delegates to client.py
+    - Returns formatted strings for LLM consumption
+    - Uses Context for structured logging and progress reporting
+"""
+
+from __future__ import annotations
+
+from fastmcp import Context
+
+from mcp_brasil._shared.formatting import format_number_br, markdown_table
+
+from . import client
+
+
+def _fmt_usd(v: float) -> str:
+    return f"US$ {format_number_br(v)}"
+
+
+def _fmt_kg(v: float) -> str:
+    return f"{format_number_br(v)} kg"
+
+
+async def consultar_exportacoes(
+    periodo_inicio: str,
+    periodo_fim: str,
+    ctx: Context,
+    ncm: str | None = None,
+    pais: str | None = None,
+    detalhar_por_mes: bool = False,
+) -> str:
+    """Query Brazilian export statistics from ComexStat (MDIC).
+
+    Returns FOB value (USD) and net weight (kg) per period, optionally broken
+    down by country and/or NCM code. Data covers monthly records since 1997.
+    Source: ComexStat MDIC — no authentication required.
+
+    Args:
+        periodo_inicio: Start period in YYYY-MM format (e.g. "2023-01").
+        periodo_fim: End period in YYYY-MM format (e.g. "2023-12").
+        ncm: Optional 8-digit NCM code to filter by product.
+        pais: Optional country ID to filter by trading partner (use listar_paises).
+        detalhar_por_mes: If True, return monthly rows; if False, aggregate by period.
+
+    Returns:
+        Markdown table with export records.
+    """
+    await ctx.info(f"Consultando exportações ComexStat: {periodo_inicio} a {periodo_fim}...")
+    itens = await client.consultar_exportacoes(
+        periodo_inicio, periodo_fim, ncm=ncm, pais=pais, detalhar_por_mes=detalhar_por_mes
+    )
+    if not itens:
+        return "Nenhum dado de exportação encontrado para os filtros informados."
+    await ctx.info(f"{len(itens)} registro(s) encontrado(s).")
+    rows = [
+        (
+            item.periodo,
+            item.pais or "—",
+            item.ncm or "—",
+            _fmt_usd(item.fob_usd),
+            _fmt_kg(item.kg_liquido),
+        )
+        for item in itens
+    ]
+    header = (
+        f"**Exportações brasileiras** — {periodo_inicio} a {periodo_fim}: "
+        f"{len(itens)} registro(s)\n"
+    )
+    return header + markdown_table(["Período", "País", "NCM", "FOB (USD)", "Peso líq. (kg)"], rows)
+
+
+async def consultar_importacoes(
+    periodo_inicio: str,
+    periodo_fim: str,
+    ctx: Context,
+    ncm: str | None = None,
+    pais: str | None = None,
+    detalhar_por_mes: bool = False,
+) -> str:
+    """Query Brazilian import statistics from ComexStat (MDIC).
+
+    Returns FOB value (USD) and net weight (kg) per period, optionally broken
+    down by country and/or NCM code. Data covers monthly records since 1997.
+    Source: ComexStat MDIC — no authentication required.
+
+    Args:
+        periodo_inicio: Start period in YYYY-MM format (e.g. "2023-01").
+        periodo_fim: End period in YYYY-MM format (e.g. "2023-12").
+        ncm: Optional 8-digit NCM code to filter by product.
+        pais: Optional country ID to filter by trading partner (use listar_paises).
+        detalhar_por_mes: If True, return monthly rows; if False, aggregate by period.
+
+    Returns:
+        Markdown table with import records.
+    """
+    await ctx.info(f"Consultando importações ComexStat: {periodo_inicio} a {periodo_fim}...")
+    itens = await client.consultar_importacoes(
+        periodo_inicio, periodo_fim, ncm=ncm, pais=pais, detalhar_por_mes=detalhar_por_mes
+    )
+    if not itens:
+        return "Nenhum dado de importação encontrado para os filtros informados."
+    await ctx.info(f"{len(itens)} registro(s) encontrado(s).")
+    rows = [
+        (
+            item.periodo,
+            item.pais or "—",
+            item.ncm or "—",
+            _fmt_usd(item.fob_usd),
+            _fmt_kg(item.kg_liquido),
+        )
+        for item in itens
+    ]
+    header = (
+        f"**Importações brasileiras** — {periodo_inicio} a {periodo_fim}: "
+        f"{len(itens)} registro(s)\n"
+    )
+    return header + markdown_table(["Período", "País", "NCM", "FOB (USD)", "Peso líq. (kg)"], rows)
+
+
+async def balanca_comercial(
+    periodo_inicio: str,
+    periodo_fim: str,
+    ctx: Context,
+    ncm: str | None = None,
+) -> str:
+    """Compute monthly trade balance (exports FOB - imports FOB) from ComexStat.
+
+    Fetches export and import data in parallel and returns the net balance
+    per month. A positive saldo indicates a trade surplus; negative is a deficit.
+    Source: ComexStat MDIC — no authentication required.
+
+    Args:
+        periodo_inicio: Start period in YYYY-MM format (e.g. "2023-01").
+        periodo_fim: End period in YYYY-MM format (e.g. "2023-12").
+        ncm: Optional 8-digit NCM code to restrict the balance to one product.
+
+    Returns:
+        Markdown table with export FOB, import FOB and trade balance per period.
+    """
+    await ctx.info(f"Calculando balança comercial: {periodo_inicio} a {periodo_fim}...")
+    itens = await client.balanca_comercial(periodo_inicio, periodo_fim, ncm=ncm)
+    if not itens:
+        return "Nenhum dado de balança comercial encontrado para os filtros informados."
+    rows = [
+        (
+            item.periodo,
+            _fmt_usd(item.exportacoes_fob),
+            _fmt_usd(item.importacoes_fob),
+            ("+" if item.saldo_fob >= 0 else "") + _fmt_usd(item.saldo_fob),
+        )
+        for item in itens
+    ]
+    header = f"**Balança Comercial** — {periodo_inicio} a {periodo_fim}: {len(itens)} período(s)\n"
+    return header + markdown_table(
+        ["Período", "Exportações FOB", "Importações FOB", "Saldo FOB"], rows
+    )
+
+
+async def listar_paises(ctx: Context) -> str:
+    """List all countries available in ComexStat trade statistics.
+
+    Returns country IDs and names (in Portuguese). Use the ID to filter
+    consultar_exportacoes or consultar_importacoes by trading partner.
+    Source: ComexStat MDIC — no authentication required.
+
+    Returns:
+        Markdown table with country ID and name.
+    """
+    await ctx.info("Listando países disponíveis no ComexStat...")
+    paises = await client.listar_paises()
+    if not paises:
+        return "Nenhum país encontrado."
+    rows = [(p.id, p.nome) for p in paises]
+    return f"**Países disponíveis no ComexStat:** {len(paises)}\n" + markdown_table(
+        ["ID", "Nome"], rows
+    )

--- a/src/mcp_brasil/data/siscomex/__init__.py
+++ b/src/mcp_brasil/data/siscomex/__init__.py
@@ -1,0 +1,16 @@
+"""Feature Siscomex — Official NCM (Mercosur Common Nomenclature) table."""
+
+from mcp_brasil._shared.feature import FeatureMeta
+
+FEATURE_META = FeatureMeta(
+    name="siscomex",
+    description=(
+        "Siscomex Portal Único: Nomenclatura Comum do Mercosul (NCM) — "
+        "tabela oficial diretamente do governo federal, com rastreamento de "
+        "vigência e referências legais para conformidade regulatória."
+    ),
+    version="0.1.0",
+    api_base="https://portalunico.siscomex.gov.br",
+    requires_auth=False,
+    tags=["ncm", "comercio-exterior", "siscomex", "receita-federal"],
+)

--- a/src/mcp_brasil/data/siscomex/client.py
+++ b/src/mcp_brasil/data/siscomex/client.py
@@ -22,6 +22,22 @@ _cache: list[NcmItem] | None = None
 _cache_expiry: float = 0.0
 
 
+def _parse_item(row: dict[str, Any]) -> NcmItem:
+    """Map raw API fields (PascalCase/underscored) to NcmItem schema fields."""
+    data_fim = row.get("Data_Fim")
+    ano_raw = row.get("Ano_Ato_Ini")
+    return NcmItem(
+        codigo=row["Codigo"],
+        descricao=row["Descricao"],
+        dataInicio=row.get("Data_Inicio"),
+        # "31/12/9999" is the API sentinel for "no expiry" — treat as None (active)
+        dataFim=None if data_fim == "31/12/9999" else data_fim,
+        tipoOrgaoAtoIni=row.get("Tipo_Ato_Ini"),
+        numeroAtoIni=row.get("Numero_Ato_Ini"),
+        anoAtoIni=int(ano_raw) if ano_raw is not None else None,
+    )
+
+
 async def _fetch_all() -> list[NcmItem]:
     """Fetch and cache the full NCM nomenclature table (TTL=24h).
 
@@ -31,8 +47,9 @@ async def _fetch_all() -> list[NcmItem]:
     if _cache is not None and time.monotonic() < _cache_expiry:
         return _cache
     async with _rate_limiter:
-        data: list[dict[str, Any]] = await http_get(NCM_BASE_URL, params=NCM_PARAMS)
-    _cache = [NcmItem(**item) for item in data]
+        data: dict[str, Any] = await http_get(NCM_BASE_URL, params=NCM_PARAMS)
+    nomenclaturas: list[dict[str, Any]] = data["Nomenclaturas"]
+    _cache = [_parse_item(row) for row in nomenclaturas]
     _cache_expiry = time.monotonic() + CACHE_TTL_SECONDS
     return _cache
 

--- a/src/mcp_brasil/data/siscomex/client.py
+++ b/src/mcp_brasil/data/siscomex/client.py
@@ -1,0 +1,54 @@
+"""HTTP client for the Siscomex feature.
+
+Endpoints:
+    - GET /classif/api/publico/nomenclatura/download/json?perfil=PUBLICO → _fetch_all
+"""
+
+from __future__ import annotations
+
+import time
+from typing import Any
+
+from mcp_brasil._shared.http_client import http_get
+from mcp_brasil._shared.rate_limiter import RateLimiter
+
+from .constants import CACHE_TTL_SECONDS, NCM_BASE_URL, NCM_MAX_RESULTS, NCM_PARAMS
+from .schemas import NcmItem
+
+# Cache (24h TTL) is the primary protection; rate limiter is a safety net
+_rate_limiter = RateLimiter(max_requests=60, period=60.0)
+
+_cache: list[NcmItem] | None = None
+_cache_expiry: float = 0.0
+
+
+async def _fetch_all() -> list[NcmItem]:
+    """Fetch and cache the full NCM nomenclature table (TTL=24h).
+
+    Concurrent initial fetches are benign in asyncio (idempotent result).
+    """
+    global _cache, _cache_expiry
+    if _cache is not None and time.monotonic() < _cache_expiry:
+        return _cache
+    async with _rate_limiter:
+        data: list[dict[str, Any]] = await http_get(NCM_BASE_URL, params=NCM_PARAMS)
+    _cache = [NcmItem(**item) for item in data]
+    _cache_expiry = time.monotonic() + CACHE_TTL_SECONDS
+    return _cache
+
+
+async def buscar_ncm(query: str, apenas_ativos: bool = True) -> list[NcmItem]:
+    """Search NCM codes by partial code or description keyword."""
+    todos = await _fetch_all()
+    if apenas_ativos:
+        todos = [item for item in todos if item.dataFim is None]
+    q = query.lower().strip()
+    resultados = [item for item in todos if q in item.codigo or q in item.descricao.lower()]
+    return resultados[:NCM_MAX_RESULTS]
+
+
+async def consultar_ncm(codigo: str) -> NcmItem | None:
+    """Fetch a specific NCM code by exact 8-digit match."""
+    todos = await _fetch_all()
+    clean = codigo.strip()
+    return next((item for item in todos if item.codigo == clean), None)

--- a/src/mcp_brasil/data/siscomex/constants.py
+++ b/src/mcp_brasil/data/siscomex/constants.py
@@ -1,0 +1,7 @@
+"""Constants for the Siscomex feature."""
+
+NCM_BASE_URL = "https://portalunico.siscomex.gov.br/classif/api/publico/nomenclatura/download/json"
+NCM_PARAMS = {"perfil": "PUBLICO"}
+
+CACHE_TTL_SECONDS = 86400  # 24h — endpoint updates at midnight daily
+NCM_MAX_RESULTS = 50

--- a/src/mcp_brasil/data/siscomex/schemas.py
+++ b/src/mcp_brasil/data/siscomex/schemas.py
@@ -1,0 +1,18 @@
+"""Pydantic schemas for the Siscomex feature."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel
+
+
+class NcmItem(BaseModel):
+    """NCM entry from the official Siscomex nomenclature table."""
+
+    codigo: str
+    descricao: str
+    dataUltimaAlteracao: str | None = None
+    dataInicio: str | None = None
+    dataFim: str | None = None
+    tipoOrgaoAtoIni: str | None = None
+    numeroAtoIni: str | None = None
+    anoAtoIni: int | None = None

--- a/src/mcp_brasil/data/siscomex/server.py
+++ b/src/mcp_brasil/data/siscomex/server.py
@@ -1,0 +1,14 @@
+"""Siscomex feature server — registers tools.
+
+This file only registers components. Zero business logic (ADR-001 rule #4).
+"""
+
+from fastmcp import FastMCP
+
+from .tools import buscar_ncm, consultar_ncm
+
+mcp = FastMCP("mcp-brasil-siscomex")
+
+# Tools (2)
+mcp.tool(buscar_ncm, tags={"busca", "ncm", "comercio-exterior"})
+mcp.tool(consultar_ncm, tags={"detalhe", "ncm", "comercio-exterior"})

--- a/src/mcp_brasil/data/siscomex/tools.py
+++ b/src/mcp_brasil/data/siscomex/tools.py
@@ -1,0 +1,85 @@
+"""Tool functions for the Siscomex feature.
+
+Rules (ADR-001):
+    - tools.py NEVER makes HTTP directly — delegates to client.py
+    - Returns formatted strings for LLM consumption
+    - Uses Context for structured logging and progress reporting
+"""
+
+from __future__ import annotations
+
+from fastmcp import Context
+
+from mcp_brasil._shared.formatting import markdown_table
+
+from . import client
+
+
+async def buscar_ncm(query: str, ctx: Context, apenas_ativos: bool = True) -> str:
+    """Search official NCM codes by partial code or description (Siscomex source).
+
+    Returns up to 50 results from the Nomenclatura Comum do Mercosul (NCM)
+    table downloaded directly from Portal Único Siscomex — official government source.
+
+    Unlike BrasilAPI, provides official validity tracking (dataInicio/dataFim)
+    and legal act references required for regulatory compliance.
+
+    Args:
+        query: Partial NCM code (e.g. "0103") or description keyword (e.g. "bovino").
+        apenas_ativos: If True (default), return only codes with no end date (currently active).
+
+    Returns:
+        Markdown table with matching NCM codes (up to 50 results).
+    """
+    await ctx.info(f"Buscando NCM Siscomex: '{query}' (apenas_ativos={apenas_ativos})...")
+    resultados = await client.buscar_ncm(query, apenas_ativos=apenas_ativos)
+    if not resultados:
+        return f"Nenhum código NCM encontrado para '{query}'."
+    await ctx.info(f"{len(resultados)} resultado(s) encontrado(s).")
+    rows = [
+        (
+            item.codigo,
+            item.descricao[:80] + ("..." if len(item.descricao) > 80 else ""),
+            item.dataInicio or "—",
+            item.dataFim or "—",
+        )
+        for item in resultados
+    ]
+    header = "**NCM encontrados"
+    if len(resultados) == 50:
+        header += " (máximo 50 — refine a busca)"
+    header += f":** {len(resultados)} resultado(s)\n"
+    return header + markdown_table(
+        ["Código", "Descrição", "Vigência início", "Vigência fim"], rows
+    )
+
+
+async def consultar_ncm(codigo: str, ctx: Context) -> str:
+    """Fetch details of a specific NCM code from the official Siscomex table.
+
+    Returns full description, validity period, and legal act references.
+    Source: Portal Único Siscomex — authoritative government data updated daily.
+
+    Args:
+        codigo: 8-digit NCM code (e.g. "01031000").
+
+    Returns:
+        NCM code details or a 'not found' message.
+    """
+    clean = codigo.strip()
+    await ctx.info(f"Consultando NCM Siscomex: {clean}...")
+    item = await client.consultar_ncm(clean)
+    if item is None:
+        return f"Código NCM **{clean}** não encontrado na tabela Siscomex."
+    ato = "—"
+    if item.tipoOrgaoAtoIni and item.numeroAtoIni and item.anoAtoIni:
+        ato = f"{item.tipoOrgaoAtoIni} nº {item.numeroAtoIni}/{item.anoAtoIni}"
+    lines = [
+        f"**Código NCM:** {item.codigo}",
+        f"**Descrição:** {item.descricao}",
+        f"**Vigência início:** {item.dataInicio or 'N/A'}",
+        f"**Vigência fim:** {item.dataFim or 'Em vigor'}",
+        f"**Última alteração:** {item.dataUltimaAlteracao or 'N/A'}",
+        f"**Ato legal:** {ato}",
+    ]
+    return "\n".join(lines)

--- a/src/mcp_brasil/server.py
+++ b/src/mcp_brasil/server.py
@@ -9,6 +9,7 @@ Usage:
     fastmcp run mcp_brasil.server:mcp --transport http --port 8000
 """
 
+import json
 import logging
 import pathlib
 import time
@@ -49,6 +50,22 @@ class RequestLoggingMiddleware(Middleware):
         name = context.message.name
         logger.info("Tool call: %s", name)
         start = time.monotonic()
+
+        # Models that serialize dict/list as JSON string — fix before Pydantic validation.
+        args = context.message.arguments or {}
+        if isinstance(args.get("arguments"), str):
+            try:
+                args["arguments"] = json.loads(args["arguments"])
+                logger.warning("Tool %s: 'arguments' recebido como string JSON — corrigido", name)
+            except json.JSONDecodeError:
+                pass  # let Pydantic reject with its original message
+        if isinstance(args.get("consultas"), str):
+            try:
+                args["consultas"] = json.loads(args["consultas"])
+                logger.warning("Tool %s: 'consultas' recebido como string JSON — corrigido", name)
+            except json.JSONDecodeError:
+                pass
+
         result = await call_next(context)
         elapsed = time.monotonic() - start
         logger.info("Tool %s completed in %.2fs", name, elapsed)

--- a/tests/_shared/test_batch.py
+++ b/tests/_shared/test_batch.py
@@ -161,6 +161,48 @@ class TestExecuteBatch:
         assert "Erro" in result
 
 
+class TestExecuteBatchStringArgs:
+    def teardown_method(self) -> None:
+        for key in ("feriados", "some_tool", "typed_tool"):
+            batch._dispatch.pop(key, None)
+
+    @pytest.mark.asyncio
+    async def test_args_as_json_string(self) -> None:
+        """Should accept args as JSON string and execute the tool normally."""
+
+        async def tool(ano: int) -> str:
+            return f"ano={ano}"
+
+        batch._dispatch["feriados"] = tool
+        ctx = _mock_ctx()
+        result = await batch.execute_batch([{"tool": "feriados", "args": '{"ano": 2026}'}], ctx)
+        assert "ano=2026" in result
+
+    @pytest.mark.asyncio
+    async def test_args_invalid_json_string_returns_error(self) -> None:
+        """Invalid JSON string should return an error in the result, not raise an exception."""
+
+        async def tool(x: int) -> str:
+            return "ok"
+
+        batch._dispatch["some_tool"] = tool
+        ctx = _mock_ctx()
+        result = await batch.execute_batch([{"tool": "some_tool", "args": "nao-e-json"}], ctx)
+        assert "não é JSON válido" in result
+
+    @pytest.mark.asyncio
+    async def test_args_wrong_type_returns_error(self) -> None:
+        """Invalid type (e.g. list) should return a descriptive error, not raise an exception."""
+
+        async def tool(x: int) -> str:
+            return "ok"
+
+        batch._dispatch["typed_tool"] = tool
+        ctx = _mock_ctx()
+        result = await batch.execute_batch([{"tool": "typed_tool", "args": [1, 2, 3]}], ctx)
+        assert "deve ser um objeto JSON" in result
+
+
 def _real_registry() -> batch.FeatureRegistry:
     """Build a real registry from the project for integration testing."""
     from mcp_brasil._shared.feature import FeatureRegistry

--- a/tests/data/comexstat/test_client.py
+++ b/tests/data/comexstat/test_client.py
@@ -1,0 +1,316 @@
+"""Tests for the ComexStat HTTP client.
+
+Uses respx to mock HTTP requests and verify response parsing.
+"""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+import respx
+
+from mcp_brasil._shared.rate_limiter import RateLimiter
+from mcp_brasil.data.comexstat import client
+from mcp_brasil.data.comexstat.constants import COUNTRY_URL, QUERY_URL
+
+_QUERY_RESPONSE_EXPORT = {
+    "data": {
+        "list": [
+            {
+                "coAnoMes": "202301",
+                "noPaisPt": "CHINA",
+                "coNcm": "01031000",
+                "metricFOB": 1_000_000.0,
+                "metricKG": 500_000.0,
+            },
+            {
+                "coAnoMes": "202302",
+                "noPaisPt": "CHINA",
+                "coNcm": "01031000",
+                "metricFOB": 1_200_000.0,
+                "metricKG": 600_000.0,
+            },
+        ]
+    }
+}
+
+_QUERY_RESPONSE_IMPORT = {
+    "data": {
+        "list": [
+            {
+                "coAnoMes": "202301",
+                "metricFOB": 800_000.0,
+                "metricKG": 400_000.0,
+            },
+        ]
+    }
+}
+
+_COUNTRY_RESPONSE = {
+    "data": {
+        "list": [
+            {"id_country": "31", "no_country_pt": "CHINA", "no_country_en": "CHINA"},
+            {"id_country": "249", "no_country_pt": "ESTADOS UNIDOS", "no_country_en": "USA"},
+        ]
+    }
+}
+
+
+# ---------------------------------------------------------------------------
+# Rate limiter
+# ---------------------------------------------------------------------------
+
+
+class TestRateLimiter:
+    def test_rate_limiter_exists(self) -> None:
+        assert hasattr(client, "_rate_limiter")
+        assert isinstance(client._rate_limiter, RateLimiter)
+
+    def test_rate_limiter_config(self) -> None:
+        assert client._rate_limiter._max_requests == 30
+        assert client._rate_limiter._period == 60.0
+
+
+# ---------------------------------------------------------------------------
+# _query
+# ---------------------------------------------------------------------------
+
+
+class TestQuery:
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_sends_correct_body_and_returns_list(self) -> None:
+        route = respx.post(QUERY_URL).mock(
+            return_value=httpx.Response(200, json=_QUERY_RESPONSE_EXPORT)
+        )
+        result = await client._query(
+            "export", "2023-01", "2023-02", ["ncm"], [], ["metricFOB"], True
+        )
+        assert route.called
+        assert len(result) == 2
+        assert result[0]["coAnoMes"] == "202301"
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_empty_list_on_no_data(self) -> None:
+        respx.post(QUERY_URL).mock(return_value=httpx.Response(200, json={"data": {"list": []}}))
+        result = await client._query("export", "2023-01", "2023-01", [], [], ["metricFOB"], False)
+        assert result == []
+
+
+# ---------------------------------------------------------------------------
+# _build_periodo
+# ---------------------------------------------------------------------------
+
+
+class TestBuildPeriodo:
+    def test_month_detail_formats_yyyy_mm(self) -> None:
+        assert client._build_periodo({"coAnoMes": "202301"}, True) == "2023-01"
+
+    def test_month_detail_short_string_passthrough(self) -> None:
+        assert client._build_periodo({"coAnoMes": "2023"}, True) == "2023"
+
+    def test_no_month_detail_returns_year(self) -> None:
+        assert client._build_periodo({"coAno": "2023"}, False) == "2023"
+
+    def test_missing_key_returns_empty(self) -> None:
+        assert client._build_periodo({}, True) == ""
+
+
+# ---------------------------------------------------------------------------
+# consultar_exportacoes
+# ---------------------------------------------------------------------------
+
+
+class TestConsultarExportacoes:
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_returns_comex_items(self) -> None:
+        respx.post(QUERY_URL).mock(return_value=httpx.Response(200, json=_QUERY_RESPONSE_EXPORT))
+        # _QUERY_RESPONSE_EXPORT uses coAnoMes keys → detalhar_por_mes=True
+        result = await client.consultar_exportacoes(
+            "2023-01", "2023-02", ncm="01031000", detalhar_por_mes=True
+        )
+        assert len(result) == 2
+        assert result[0].periodo == "2023-01"
+        assert result[0].pais == "CHINA"
+        assert result[0].ncm == "01031000"
+        assert result[0].fob_usd == 1_000_000.0
+        assert result[0].kg_liquido == 500_000.0
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_no_filters_returns_items(self) -> None:
+        respx.post(QUERY_URL).mock(return_value=httpx.Response(200, json=_QUERY_RESPONSE_EXPORT))
+        result = await client.consultar_exportacoes("2023-01", "2023-02")
+        assert len(result) == 2
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_empty_response_returns_empty_list(self) -> None:
+        respx.post(QUERY_URL).mock(return_value=httpx.Response(200, json={"data": {"list": []}}))
+        result = await client.consultar_exportacoes("2023-01", "2023-01")
+        assert result == []
+
+
+# ---------------------------------------------------------------------------
+# consultar_importacoes
+# ---------------------------------------------------------------------------
+
+
+class TestConsultarImportacoes:
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_returns_comex_items(self) -> None:
+        respx.post(QUERY_URL).mock(return_value=httpx.Response(200, json=_QUERY_RESPONSE_IMPORT))
+        result = await client.consultar_importacoes("2023-01", "2023-01")
+        assert len(result) == 1
+        assert result[0].fob_usd == 800_000.0
+        assert result[0].pais is None
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_empty_response_returns_empty_list(self) -> None:
+        respx.post(QUERY_URL).mock(return_value=httpx.Response(200, json={"data": {"list": []}}))
+        result = await client.consultar_importacoes("2023-01", "2023-01")
+        assert result == []
+
+
+# ---------------------------------------------------------------------------
+# balanca_comercial
+# ---------------------------------------------------------------------------
+
+
+class TestBalancaComercial:
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_surplus_period(self) -> None:
+        respx.post(QUERY_URL).mock(
+            side_effect=[
+                httpx.Response(
+                    200,
+                    json={"data": {"list": [{"coAnoMes": "202301", "metricFOB": 1_000_000.0}]}},
+                ),
+                httpx.Response(
+                    200,
+                    json={"data": {"list": [{"coAnoMes": "202301", "metricFOB": 600_000.0}]}},
+                ),
+            ]
+        )
+        result = await client.balanca_comercial("2023-01", "2023-01")
+        assert len(result) == 1
+        assert result[0].periodo == "2023-01"
+        assert result[0].exportacoes_fob == 1_000_000.0
+        assert result[0].importacoes_fob == 600_000.0
+        assert result[0].saldo_fob == 400_000.0
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_deficit_period(self) -> None:
+        respx.post(QUERY_URL).mock(
+            side_effect=[
+                httpx.Response(
+                    200,
+                    json={"data": {"list": [{"coAnoMes": "202301", "metricFOB": 300_000.0}]}},
+                ),
+                httpx.Response(
+                    200,
+                    json={"data": {"list": [{"coAnoMes": "202301", "metricFOB": 800_000.0}]}},
+                ),
+            ]
+        )
+        result = await client.balanca_comercial("2023-01", "2023-01")
+        assert result[0].saldo_fob == pytest.approx(-500_000.0)
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_merges_multiple_periods_sorted(self) -> None:
+        respx.post(QUERY_URL).mock(
+            side_effect=[
+                httpx.Response(
+                    200,
+                    json={
+                        "data": {
+                            "list": [
+                                {"coAnoMes": "202302", "metricFOB": 500_000.0},
+                                {"coAnoMes": "202301", "metricFOB": 400_000.0},
+                            ]
+                        }
+                    },
+                ),
+                httpx.Response(
+                    200,
+                    json={
+                        "data": {
+                            "list": [
+                                {"coAnoMes": "202301", "metricFOB": 200_000.0},
+                                {"coAnoMes": "202302", "metricFOB": 300_000.0},
+                            ]
+                        }
+                    },
+                ),
+            ]
+        )
+        result = await client.balanca_comercial("2023-01", "2023-02")
+        assert len(result) == 2
+        assert result[0].periodo == "2023-01"
+        assert result[1].periodo == "2023-02"
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_period_only_in_exports_gets_zero_imports(self) -> None:
+        respx.post(QUERY_URL).mock(
+            side_effect=[
+                httpx.Response(
+                    200,
+                    json={"data": {"list": [{"coAnoMes": "202301", "metricFOB": 500_000.0}]}},
+                ),
+                httpx.Response(200, json={"data": {"list": []}}),
+            ]
+        )
+        result = await client.balanca_comercial("2023-01", "2023-01")
+        assert result[0].importacoes_fob == 0.0
+        assert result[0].saldo_fob == 500_000.0
+
+
+# ---------------------------------------------------------------------------
+# listar_paises
+# ---------------------------------------------------------------------------
+
+
+class TestListarPaises:
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_parses_countries(self) -> None:
+        respx.get(COUNTRY_URL).mock(return_value=httpx.Response(200, json=_COUNTRY_RESPONSE))
+        result = await client.listar_paises()
+        assert len(result) == 2
+        assert result[0].id == "31"
+        assert result[0].nome == "CHINA"
+        assert result[1].id == "249"
+        assert result[1].nome == "ESTADOS UNIDOS"
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_fallback_to_english_name(self) -> None:
+        respx.get(COUNTRY_URL).mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "data": {
+                        "list": [
+                            {"id_country": "1", "no_country_pt": None, "no_country_en": "UNKNOWN"}
+                        ]
+                    }
+                },
+            )
+        )
+        result = await client.listar_paises()
+        assert result[0].nome == "UNKNOWN"
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_empty_list(self) -> None:
+        respx.get(COUNTRY_URL).mock(return_value=httpx.Response(200, json={"data": {"list": []}}))
+        result = await client.listar_paises()
+        assert result == []

--- a/tests/data/comexstat/test_client.py
+++ b/tests/data/comexstat/test_client.py
@@ -1,9 +1,12 @@
 """Tests for the ComexStat HTTP client.
 
-Uses respx to mock HTTP requests and verify response parsing.
+Uses respx to mock HTTP GET requests and unittest.mock for curl_cffi POST.
 """
 
 from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx
 import pytest
@@ -11,49 +14,61 @@ import respx
 
 from mcp_brasil._shared.rate_limiter import RateLimiter
 from mcp_brasil.data.comexstat import client
-from mcp_brasil.data.comexstat.constants import COUNTRY_URL, QUERY_URL
+from mcp_brasil.data.comexstat.constants import COUNTRY_URL
 
-_QUERY_RESPONSE_EXPORT = {
-    "data": {
-        "list": [
-            {
-                "coAnoMes": "202301",
-                "noPaisPt": "CHINA",
-                "coNcm": "01031000",
-                "metricFOB": 1_000_000.0,
-                "metricKG": 500_000.0,
-            },
-            {
-                "coAnoMes": "202302",
-                "noPaisPt": "CHINA",
-                "coNcm": "01031000",
-                "metricFOB": 1_200_000.0,
-                "metricKG": 600_000.0,
-            },
-        ]
-    }
-}
+# Real API field names (as of 2026-05)
+_EXPORT_ROWS = [
+    {
+        "year": "2023",
+        "monthNumber": "1",
+        "country": "China",
+        "ncm": "01031000",
+        "metricFOB": 1_000_000.0,
+        "metricKG": 500_000.0,
+    },
+    {
+        "year": "2023",
+        "monthNumber": "2",
+        "country": "China",
+        "ncm": "01031000",
+        "metricFOB": 1_200_000.0,
+        "metricKG": 600_000.0,
+    },
+]
 
-_QUERY_RESPONSE_IMPORT = {
-    "data": {
-        "list": [
-            {
-                "coAnoMes": "202301",
-                "metricFOB": 800_000.0,
-                "metricKG": 400_000.0,
-            },
-        ]
-    }
-}
+_IMPORT_ROWS = [
+    {
+        "year": "2023",
+        "monthNumber": "1",
+        "metricFOB": 800_000.0,
+        "metricKG": 400_000.0,
+    },
+]
+
+_QUERY_RESPONSE_EXPORT = {"data": {"list": _EXPORT_ROWS}}
+_QUERY_RESPONSE_IMPORT = {"data": {"list": _IMPORT_ROWS}}
 
 _COUNTRY_RESPONSE = {
-    "data": {
-        "list": [
-            {"id_country": "31", "no_country_pt": "CHINA", "no_country_en": "CHINA"},
-            {"id_country": "249", "no_country_pt": "ESTADOS UNIDOS", "no_country_en": "USA"},
+    "data": [
+        [
+            {"id": "31", "text": "China"},
+            {"id": "249", "text": "Estados Unidos"},
         ]
-    }
+    ]
 }
+
+
+def _mock_curl_session(json_data: dict[str, Any]) -> MagicMock:
+    """Return a mock AsyncSession that responds with json_data."""
+    mock_response = MagicMock()
+    mock_response.raise_for_status = MagicMock()
+    mock_response.json = MagicMock(return_value=json_data)
+
+    mock_session = AsyncMock()
+    mock_session.post = AsyncMock(return_value=mock_response)
+    mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+    mock_session.__aexit__ = AsyncMock(return_value=None)
+    return mock_session
 
 
 # ---------------------------------------------------------------------------
@@ -72,49 +87,48 @@ class TestRateLimiter:
 
 
 # ---------------------------------------------------------------------------
-# _query
-# ---------------------------------------------------------------------------
-
-
-class TestQuery:
-    @pytest.mark.asyncio
-    @respx.mock
-    async def test_sends_correct_body_and_returns_list(self) -> None:
-        route = respx.post(QUERY_URL).mock(
-            return_value=httpx.Response(200, json=_QUERY_RESPONSE_EXPORT)
-        )
-        result = await client._query(
-            "export", "2023-01", "2023-02", ["ncm"], [], ["metricFOB"], True
-        )
-        assert route.called
-        assert len(result) == 2
-        assert result[0]["coAnoMes"] == "202301"
-
-    @pytest.mark.asyncio
-    @respx.mock
-    async def test_empty_list_on_no_data(self) -> None:
-        respx.post(QUERY_URL).mock(return_value=httpx.Response(200, json={"data": {"list": []}}))
-        result = await client._query("export", "2023-01", "2023-01", [], [], ["metricFOB"], False)
-        assert result == []
-
-
-# ---------------------------------------------------------------------------
 # _build_periodo
 # ---------------------------------------------------------------------------
 
 
 class TestBuildPeriodo:
     def test_month_detail_formats_yyyy_mm(self) -> None:
-        assert client._build_periodo({"coAnoMes": "202301"}, True) == "2023-01"
+        assert client._build_periodo({"year": "2023", "monthNumber": "1"}, True) == "2023-01"
 
-    def test_month_detail_short_string_passthrough(self) -> None:
-        assert client._build_periodo({"coAnoMes": "2023"}, True) == "2023"
+    def test_month_detail_pads_month(self) -> None:
+        assert client._build_periodo({"year": "2023", "monthNumber": "12"}, True) == "2023-12"
 
     def test_no_month_detail_returns_year(self) -> None:
-        assert client._build_periodo({"coAno": "2023"}, False) == "2023"
+        assert client._build_periodo({"year": "2023"}, False) == "2023"
 
     def test_missing_key_returns_empty(self) -> None:
         assert client._build_periodo({}, True) == ""
+
+
+# ---------------------------------------------------------------------------
+# _query
+# ---------------------------------------------------------------------------
+
+
+class TestQuery:
+    @pytest.mark.asyncio
+    async def test_sends_correct_body_and_returns_list(self) -> None:
+        mock_session = _mock_curl_session(_QUERY_RESPONSE_EXPORT)
+        with patch("mcp_brasil.data.comexstat.client.AsyncSession", return_value=mock_session):
+            result = await client._query(
+                "export", "2023-01", "2023-02", ["ncm"], [], ["metricFOB"], True
+            )
+        assert len(result) == 2
+        assert result[0]["year"] == "2023"
+
+    @pytest.mark.asyncio
+    async def test_empty_list_on_no_data(self) -> None:
+        mock_session = _mock_curl_session({"data": {"list": []}})
+        with patch("mcp_brasil.data.comexstat.client.AsyncSession", return_value=mock_session):
+            result = await client._query(
+                "export", "2023-01", "2023-01", [], [], ["metricFOB"], False
+            )
+        assert result == []
 
 
 # ---------------------------------------------------------------------------
@@ -124,32 +138,28 @@ class TestBuildPeriodo:
 
 class TestConsultarExportacoes:
     @pytest.mark.asyncio
-    @respx.mock
     async def test_returns_comex_items(self) -> None:
-        respx.post(QUERY_URL).mock(return_value=httpx.Response(200, json=_QUERY_RESPONSE_EXPORT))
-        # _QUERY_RESPONSE_EXPORT uses coAnoMes keys → detalhar_por_mes=True
-        result = await client.consultar_exportacoes(
-            "2023-01", "2023-02", ncm="01031000", detalhar_por_mes=True
-        )
+        with patch.object(client, "_query", new=AsyncMock(return_value=_EXPORT_ROWS)):
+            result = await client.consultar_exportacoes(
+                "2023-01", "2023-02", ncm="01031000", detalhar_por_mes=True
+            )
         assert len(result) == 2
         assert result[0].periodo == "2023-01"
-        assert result[0].pais == "CHINA"
+        assert result[0].pais == "China"
         assert result[0].ncm == "01031000"
         assert result[0].fob_usd == 1_000_000.0
         assert result[0].kg_liquido == 500_000.0
 
     @pytest.mark.asyncio
-    @respx.mock
     async def test_no_filters_returns_items(self) -> None:
-        respx.post(QUERY_URL).mock(return_value=httpx.Response(200, json=_QUERY_RESPONSE_EXPORT))
-        result = await client.consultar_exportacoes("2023-01", "2023-02")
+        with patch.object(client, "_query", new=AsyncMock(return_value=_EXPORT_ROWS)):
+            result = await client.consultar_exportacoes("2023-01", "2023-02")
         assert len(result) == 2
 
     @pytest.mark.asyncio
-    @respx.mock
     async def test_empty_response_returns_empty_list(self) -> None:
-        respx.post(QUERY_URL).mock(return_value=httpx.Response(200, json={"data": {"list": []}}))
-        result = await client.consultar_exportacoes("2023-01", "2023-01")
+        with patch.object(client, "_query", new=AsyncMock(return_value=[])):
+            result = await client.consultar_exportacoes("2023-01", "2023-01")
         assert result == []
 
 
@@ -160,19 +170,17 @@ class TestConsultarExportacoes:
 
 class TestConsultarImportacoes:
     @pytest.mark.asyncio
-    @respx.mock
     async def test_returns_comex_items(self) -> None:
-        respx.post(QUERY_URL).mock(return_value=httpx.Response(200, json=_QUERY_RESPONSE_IMPORT))
-        result = await client.consultar_importacoes("2023-01", "2023-01")
+        with patch.object(client, "_query", new=AsyncMock(return_value=_IMPORT_ROWS)):
+            result = await client.consultar_importacoes("2023-01", "2023-01")
         assert len(result) == 1
         assert result[0].fob_usd == 800_000.0
         assert result[0].pais is None
 
     @pytest.mark.asyncio
-    @respx.mock
     async def test_empty_response_returns_empty_list(self) -> None:
-        respx.post(QUERY_URL).mock(return_value=httpx.Response(200, json={"data": {"list": []}}))
-        result = await client.consultar_importacoes("2023-01", "2023-01")
+        with patch.object(client, "_query", new=AsyncMock(return_value=[])):
+            result = await client.consultar_importacoes("2023-01", "2023-01")
         assert result == []
 
 
@@ -183,21 +191,11 @@ class TestConsultarImportacoes:
 
 class TestBalancaComercial:
     @pytest.mark.asyncio
-    @respx.mock
     async def test_surplus_period(self) -> None:
-        respx.post(QUERY_URL).mock(
-            side_effect=[
-                httpx.Response(
-                    200,
-                    json={"data": {"list": [{"coAnoMes": "202301", "metricFOB": 1_000_000.0}]}},
-                ),
-                httpx.Response(
-                    200,
-                    json={"data": {"list": [{"coAnoMes": "202301", "metricFOB": 600_000.0}]}},
-                ),
-            ]
-        )
-        result = await client.balanca_comercial("2023-01", "2023-01")
+        exp = [{"year": "2023", "monthNumber": "1", "metricFOB": 1_000_000.0}]
+        imp = [{"year": "2023", "monthNumber": "1", "metricFOB": 600_000.0}]
+        with patch.object(client, "_query", new=AsyncMock(side_effect=[exp, imp])):
+            result = await client.balanca_comercial("2023-01", "2023-01")
         assert len(result) == 1
         assert result[0].periodo == "2023-01"
         assert result[0].exportacoes_fob == 1_000_000.0
@@ -205,70 +203,34 @@ class TestBalancaComercial:
         assert result[0].saldo_fob == 400_000.0
 
     @pytest.mark.asyncio
-    @respx.mock
     async def test_deficit_period(self) -> None:
-        respx.post(QUERY_URL).mock(
-            side_effect=[
-                httpx.Response(
-                    200,
-                    json={"data": {"list": [{"coAnoMes": "202301", "metricFOB": 300_000.0}]}},
-                ),
-                httpx.Response(
-                    200,
-                    json={"data": {"list": [{"coAnoMes": "202301", "metricFOB": 800_000.0}]}},
-                ),
-            ]
-        )
-        result = await client.balanca_comercial("2023-01", "2023-01")
+        exp = [{"year": "2023", "monthNumber": "1", "metricFOB": 300_000.0}]
+        imp = [{"year": "2023", "monthNumber": "1", "metricFOB": 800_000.0}]
+        with patch.object(client, "_query", new=AsyncMock(side_effect=[exp, imp])):
+            result = await client.balanca_comercial("2023-01", "2023-01")
         assert result[0].saldo_fob == pytest.approx(-500_000.0)
 
     @pytest.mark.asyncio
-    @respx.mock
     async def test_merges_multiple_periods_sorted(self) -> None:
-        respx.post(QUERY_URL).mock(
-            side_effect=[
-                httpx.Response(
-                    200,
-                    json={
-                        "data": {
-                            "list": [
-                                {"coAnoMes": "202302", "metricFOB": 500_000.0},
-                                {"coAnoMes": "202301", "metricFOB": 400_000.0},
-                            ]
-                        }
-                    },
-                ),
-                httpx.Response(
-                    200,
-                    json={
-                        "data": {
-                            "list": [
-                                {"coAnoMes": "202301", "metricFOB": 200_000.0},
-                                {"coAnoMes": "202302", "metricFOB": 300_000.0},
-                            ]
-                        }
-                    },
-                ),
-            ]
-        )
-        result = await client.balanca_comercial("2023-01", "2023-02")
+        exp = [
+            {"year": "2023", "monthNumber": "2", "metricFOB": 500_000.0},
+            {"year": "2023", "monthNumber": "1", "metricFOB": 400_000.0},
+        ]
+        imp = [
+            {"year": "2023", "monthNumber": "1", "metricFOB": 200_000.0},
+            {"year": "2023", "monthNumber": "2", "metricFOB": 300_000.0},
+        ]
+        with patch.object(client, "_query", new=AsyncMock(side_effect=[exp, imp])):
+            result = await client.balanca_comercial("2023-01", "2023-02")
         assert len(result) == 2
         assert result[0].periodo == "2023-01"
         assert result[1].periodo == "2023-02"
 
     @pytest.mark.asyncio
-    @respx.mock
     async def test_period_only_in_exports_gets_zero_imports(self) -> None:
-        respx.post(QUERY_URL).mock(
-            side_effect=[
-                httpx.Response(
-                    200,
-                    json={"data": {"list": [{"coAnoMes": "202301", "metricFOB": 500_000.0}]}},
-                ),
-                httpx.Response(200, json={"data": {"list": []}}),
-            ]
-        )
-        result = await client.balanca_comercial("2023-01", "2023-01")
+        exp = [{"year": "2023", "monthNumber": "1", "metricFOB": 500_000.0}]
+        with patch.object(client, "_query", new=AsyncMock(side_effect=[exp, []])):
+            result = await client.balanca_comercial("2023-01", "2023-01")
         assert result[0].importacoes_fob == 0.0
         assert result[0].saldo_fob == 500_000.0
 
@@ -286,31 +248,20 @@ class TestListarPaises:
         result = await client.listar_paises()
         assert len(result) == 2
         assert result[0].id == "31"
-        assert result[0].nome == "CHINA"
+        assert result[0].nome == "China"
         assert result[1].id == "249"
-        assert result[1].nome == "ESTADOS UNIDOS"
+        assert result[1].nome == "Estados Unidos"
 
     @pytest.mark.asyncio
     @respx.mock
-    async def test_fallback_to_english_name(self) -> None:
-        respx.get(COUNTRY_URL).mock(
-            return_value=httpx.Response(
-                200,
-                json={
-                    "data": {
-                        "list": [
-                            {"id_country": "1", "no_country_pt": None, "no_country_en": "UNKNOWN"}
-                        ]
-                    }
-                },
-            )
-        )
+    async def test_empty_inner_list(self) -> None:
+        respx.get(COUNTRY_URL).mock(return_value=httpx.Response(200, json={"data": [[]]}))
         result = await client.listar_paises()
-        assert result[0].nome == "UNKNOWN"
+        assert result == []
 
     @pytest.mark.asyncio
     @respx.mock
-    async def test_empty_list(self) -> None:
-        respx.get(COUNTRY_URL).mock(return_value=httpx.Response(200, json={"data": {"list": []}}))
+    async def test_empty_data(self) -> None:
+        respx.get(COUNTRY_URL).mock(return_value=httpx.Response(200, json={"data": []}))
         result = await client.listar_paises()
         assert result == []

--- a/tests/data/comexstat/test_integration.py
+++ b/tests/data/comexstat/test_integration.py
@@ -1,0 +1,37 @@
+"""Integration tests for the ComexStat feature using fastmcp.Client.
+
+These tests verify the full pipeline: server registration and tool execution.
+"""
+
+import pytest
+from fastmcp import Client
+
+from mcp_brasil.data.comexstat.server import mcp
+
+
+class TestToolsRegistered:
+    @pytest.mark.asyncio
+    async def test_all_tools_registered(self) -> None:
+        async with Client(mcp) as c:
+            tool_list = await c.list_tools()
+            names = {t.name for t in tool_list}
+            expected = {
+                "consultar_exportacoes",
+                "consultar_importacoes",
+                "balanca_comercial",
+                "listar_paises",
+            }
+            assert expected.issubset(names), f"Missing: {expected - names}"
+
+    @pytest.mark.asyncio
+    async def test_tools_have_docstrings(self) -> None:
+        async with Client(mcp) as c:
+            tool_list = await c.list_tools()
+            for tool in tool_list:
+                assert tool.description, f"Tool {tool.name} has no description"
+
+    @pytest.mark.asyncio
+    async def test_tool_count(self) -> None:
+        async with Client(mcp) as c:
+            tool_list = await c.list_tools()
+            assert len(tool_list) == 4

--- a/tests/data/comexstat/test_tools.py
+++ b/tests/data/comexstat/test_tools.py
@@ -1,0 +1,240 @@
+"""Tests for the ComexStat tool functions.
+
+Tools are tested by mocking client functions (never HTTP).
+Context is mocked via MagicMock with async methods.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from mcp_brasil.data.comexstat import tools
+from mcp_brasil.data.comexstat.schemas import BalancaItem, ComexItem, PaisItem
+
+CLIENT_MODULE = "mcp_brasil.data.comexstat.client"
+
+
+def _mock_ctx() -> MagicMock:
+    ctx = MagicMock()
+    ctx.info = AsyncMock()
+    ctx.warning = AsyncMock()
+    return ctx
+
+
+# ---------------------------------------------------------------------------
+# consultar_exportacoes
+# ---------------------------------------------------------------------------
+
+
+class TestConsultarExportacoes:
+    @pytest.mark.asyncio
+    async def test_formats_as_table(self) -> None:
+        itens = [
+            ComexItem(
+                periodo="2023-01",
+                pais="CHINA",
+                ncm="01031000",
+                fob_usd=1_000_000.0,
+                kg_liquido=500_000.0,
+            )
+        ]
+        ctx = _mock_ctx()
+        with patch(
+            f"{CLIENT_MODULE}.consultar_exportacoes",
+            new_callable=AsyncMock,
+            return_value=itens,
+        ):
+            result = await tools.consultar_exportacoes("2023-01", "2023-01", ctx)
+        assert "2023-01" in result
+        assert "CHINA" in result
+        assert "01031000" in result
+        assert "US$" in result
+        assert "kg" in result
+
+    @pytest.mark.asyncio
+    async def test_empty_returns_message(self) -> None:
+        ctx = _mock_ctx()
+        with patch(
+            f"{CLIENT_MODULE}.consultar_exportacoes",
+            new_callable=AsyncMock,
+            return_value=[],
+        ):
+            result = await tools.consultar_exportacoes("2023-01", "2023-01", ctx)
+        assert "Nenhum" in result
+
+    @pytest.mark.asyncio
+    async def test_none_pais_shows_dash(self) -> None:
+        itens = [
+            ComexItem(periodo="2023-01", pais=None, ncm=None, fob_usd=500.0, kg_liquido=100.0)
+        ]
+        ctx = _mock_ctx()
+        with patch(
+            f"{CLIENT_MODULE}.consultar_exportacoes",
+            new_callable=AsyncMock,
+            return_value=itens,
+        ):
+            result = await tools.consultar_exportacoes("2023-01", "2023-01", ctx)
+        assert "—" in result
+
+    @pytest.mark.asyncio
+    async def test_header_contains_periodo_range(self) -> None:
+        itens = [ComexItem(periodo="2023-01", fob_usd=0.0, kg_liquido=0.0)]
+        ctx = _mock_ctx()
+        with patch(
+            f"{CLIENT_MODULE}.consultar_exportacoes",
+            new_callable=AsyncMock,
+            return_value=itens,
+        ):
+            result = await tools.consultar_exportacoes("2023-01", "2023-06", ctx)
+        assert "2023-01" in result
+        assert "2023-06" in result
+
+
+# ---------------------------------------------------------------------------
+# consultar_importacoes
+# ---------------------------------------------------------------------------
+
+
+class TestConsultarImportacoes:
+    @pytest.mark.asyncio
+    async def test_formats_as_table(self) -> None:
+        itens = [
+            ComexItem(
+                periodo="2023-03",
+                pais="EUA",
+                ncm="84713012",
+                fob_usd=2_500_000.0,
+                kg_liquido=10_000.0,
+            )
+        ]
+        ctx = _mock_ctx()
+        with patch(
+            f"{CLIENT_MODULE}.consultar_importacoes",
+            new_callable=AsyncMock,
+            return_value=itens,
+        ):
+            result = await tools.consultar_importacoes("2023-01", "2023-03", ctx)
+        assert "2023-03" in result
+        assert "EUA" in result
+        assert "Importações" in result
+
+    @pytest.mark.asyncio
+    async def test_empty_returns_message(self) -> None:
+        ctx = _mock_ctx()
+        with patch(
+            f"{CLIENT_MODULE}.consultar_importacoes",
+            new_callable=AsyncMock,
+            return_value=[],
+        ):
+            result = await tools.consultar_importacoes("2023-01", "2023-01", ctx)
+        assert "Nenhum" in result
+
+
+# ---------------------------------------------------------------------------
+# balanca_comercial
+# ---------------------------------------------------------------------------
+
+
+class TestBalancaComercial:
+    @pytest.mark.asyncio
+    async def test_surplus_shows_plus_sign(self) -> None:
+        itens = [
+            BalancaItem(
+                periodo="2023-01",
+                exportacoes_fob=1_000_000.0,
+                importacoes_fob=600_000.0,
+                saldo_fob=400_000.0,
+            )
+        ]
+        ctx = _mock_ctx()
+        with patch(
+            f"{CLIENT_MODULE}.balanca_comercial",
+            new_callable=AsyncMock,
+            return_value=itens,
+        ):
+            result = await tools.balanca_comercial("2023-01", "2023-01", ctx)
+        assert "+US$" in result
+
+    @pytest.mark.asyncio
+    async def test_deficit_shows_negative(self) -> None:
+        itens = [
+            BalancaItem(
+                periodo="2023-01",
+                exportacoes_fob=300_000.0,
+                importacoes_fob=800_000.0,
+                saldo_fob=-500_000.0,
+            )
+        ]
+        ctx = _mock_ctx()
+        with patch(
+            f"{CLIENT_MODULE}.balanca_comercial",
+            new_callable=AsyncMock,
+            return_value=itens,
+        ):
+            result = await tools.balanca_comercial("2023-01", "2023-01", ctx)
+        assert "US$ -" in result or "-US$" in result or "500" in result
+
+    @pytest.mark.asyncio
+    async def test_empty_returns_message(self) -> None:
+        ctx = _mock_ctx()
+        with patch(
+            f"{CLIENT_MODULE}.balanca_comercial",
+            new_callable=AsyncMock,
+            return_value=[],
+        ):
+            result = await tools.balanca_comercial("2023-01", "2023-01", ctx)
+        assert "Nenhum" in result
+
+    @pytest.mark.asyncio
+    async def test_header_contains_balanca(self) -> None:
+        itens = [
+            BalancaItem(periodo="2023-01", exportacoes_fob=0.0, importacoes_fob=0.0, saldo_fob=0.0)
+        ]
+        ctx = _mock_ctx()
+        with patch(
+            f"{CLIENT_MODULE}.balanca_comercial",
+            new_callable=AsyncMock,
+            return_value=itens,
+        ):
+            result = await tools.balanca_comercial("2023-01", "2023-03", ctx)
+        assert "Balança" in result
+        assert "2023-01" in result
+        assert "2023-03" in result
+
+
+# ---------------------------------------------------------------------------
+# listar_paises
+# ---------------------------------------------------------------------------
+
+
+class TestListarPaises:
+    @pytest.mark.asyncio
+    async def test_formats_table_with_id_and_nome(self) -> None:
+        paises = [
+            PaisItem(id="31", nome="CHINA"),
+            PaisItem(id="249", nome="ESTADOS UNIDOS"),
+        ]
+        ctx = _mock_ctx()
+        with patch(f"{CLIENT_MODULE}.listar_paises", new_callable=AsyncMock, return_value=paises):
+            result = await tools.listar_paises(ctx)
+        assert "31" in result
+        assert "CHINA" in result
+        assert "249" in result
+        assert "ESTADOS UNIDOS" in result
+
+    @pytest.mark.asyncio
+    async def test_empty_returns_message(self) -> None:
+        ctx = _mock_ctx()
+        with patch(f"{CLIENT_MODULE}.listar_paises", new_callable=AsyncMock, return_value=[]):
+            result = await tools.listar_paises(ctx)
+        assert "Nenhum" in result
+
+    @pytest.mark.asyncio
+    async def test_header_shows_count(self) -> None:
+        paises = [PaisItem(id=str(i), nome=f"País {i}") for i in range(5)]
+        ctx = _mock_ctx()
+        with patch(f"{CLIENT_MODULE}.listar_paises", new_callable=AsyncMock, return_value=paises):
+            result = await tools.listar_paises(ctx)
+        assert "5" in result

--- a/tests/data/siscomex/test_client.py
+++ b/tests/data/siscomex/test_client.py
@@ -1,0 +1,182 @@
+"""Tests for the Siscomex HTTP client.
+
+Uses respx to mock HTTP requests and verify response parsing and caching.
+"""
+
+from __future__ import annotations
+
+import time
+
+import httpx
+import pytest
+import respx
+
+from mcp_brasil._shared.rate_limiter import RateLimiter
+from mcp_brasil.data.siscomex import client
+from mcp_brasil.data.siscomex.constants import NCM_BASE_URL
+from mcp_brasil.data.siscomex.schemas import NcmItem
+
+_NCM_SAMPLE: list[dict] = [
+    {
+        "codigo": "01031000",
+        "descricao": "Reprodutores de raça pura",
+        "dataUltimaAlteracao": "2024-01-01",
+        "dataInicio": "2022-01-01",
+        "dataFim": None,
+        "tipoOrgaoAtoIni": "Resolução",
+        "numeroAtoIni": "123",
+        "anoAtoIni": 2022,
+    },
+    {
+        "codigo": "01039000",
+        "descricao": "Outros suínos vivos",
+        "dataUltimaAlteracao": "2020-01-01",
+        "dataInicio": "2019-01-01",
+        "dataFim": "2021-12-31",
+        "tipoOrgaoAtoIni": None,
+        "numeroAtoIni": None,
+        "anoAtoIni": None,
+    },
+]
+
+
+def _reset_cache() -> None:
+    client._cache = None
+    client._cache_expiry = 0.0
+
+
+# ---------------------------------------------------------------------------
+# Rate limiter
+# ---------------------------------------------------------------------------
+
+
+class TestRateLimiter:
+    def test_rate_limiter_exists(self) -> None:
+        assert hasattr(client, "_rate_limiter")
+        assert isinstance(client._rate_limiter, RateLimiter)
+
+    def test_rate_limiter_config(self) -> None:
+        assert client._rate_limiter._max_requests == 60
+        assert client._rate_limiter._period == 60.0
+
+
+# ---------------------------------------------------------------------------
+# _fetch_all
+# ---------------------------------------------------------------------------
+
+
+class TestFetchAll:
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_parses_ncm_items(self) -> None:
+        _reset_cache()
+        respx.get(NCM_BASE_URL).mock(return_value=httpx.Response(200, json=_NCM_SAMPLE))
+        result = await client._fetch_all()
+        assert len(result) == 2
+        assert result[0].codigo == "01031000"
+        assert result[0].descricao == "Reprodutores de raça pura"
+        assert result[1].dataFim == "2021-12-31"
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_populates_cache(self) -> None:
+        _reset_cache()
+        respx.get(NCM_BASE_URL).mock(return_value=httpx.Response(200, json=_NCM_SAMPLE))
+        await client._fetch_all()
+        assert client._cache is not None
+        assert client._cache_expiry > time.monotonic()
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_cache_hit_skips_http(self) -> None:
+        client._cache = [NcmItem(codigo="99999999", descricao="Cached item")]
+        client._cache_expiry = time.monotonic() + 9999
+        route = respx.get(NCM_BASE_URL).mock(return_value=httpx.Response(200, json=[]))
+        result = await client._fetch_all()
+        assert not route.called
+        assert result[0].codigo == "99999999"
+        _reset_cache()
+
+
+# ---------------------------------------------------------------------------
+# buscar_ncm
+# ---------------------------------------------------------------------------
+
+
+class TestBuscarNcm:
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_filters_by_code_prefix(self) -> None:
+        _reset_cache()
+        respx.get(NCM_BASE_URL).mock(return_value=httpx.Response(200, json=_NCM_SAMPLE))
+        result = await client.buscar_ncm("01031")
+        assert len(result) == 1
+        assert result[0].codigo == "01031000"
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_filters_by_description(self) -> None:
+        _reset_cache()
+        respx.get(NCM_BASE_URL).mock(return_value=httpx.Response(200, json=_NCM_SAMPLE))
+        result = await client.buscar_ncm("reprodutores")
+        assert len(result) == 1
+        assert result[0].codigo == "01031000"
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_apenas_ativos_excludes_expired(self) -> None:
+        _reset_cache()
+        respx.get(NCM_BASE_URL).mock(return_value=httpx.Response(200, json=_NCM_SAMPLE))
+        result = await client.buscar_ncm("01", apenas_ativos=True)
+        assert all(item.dataFim is None for item in result)
+        assert len(result) == 1
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_apenas_ativos_false_includes_all(self) -> None:
+        _reset_cache()
+        respx.get(NCM_BASE_URL).mock(return_value=httpx.Response(200, json=_NCM_SAMPLE))
+        result = await client.buscar_ncm("01", apenas_ativos=False)
+        assert len(result) == 2
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_empty_when_no_match(self) -> None:
+        _reset_cache()
+        respx.get(NCM_BASE_URL).mock(return_value=httpx.Response(200, json=_NCM_SAMPLE))
+        result = await client.buscar_ncm("xyzxyz")
+        assert result == []
+
+
+# ---------------------------------------------------------------------------
+# consultar_ncm
+# ---------------------------------------------------------------------------
+
+
+class TestConsultarNcm:
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_returns_exact_match(self) -> None:
+        _reset_cache()
+        respx.get(NCM_BASE_URL).mock(return_value=httpx.Response(200, json=_NCM_SAMPLE))
+        result = await client.consultar_ncm("01031000")
+        assert result is not None
+        assert result.codigo == "01031000"
+        assert result.descricao == "Reprodutores de raça pura"
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_returns_none_when_not_found(self) -> None:
+        _reset_cache()
+        respx.get(NCM_BASE_URL).mock(return_value=httpx.Response(200, json=_NCM_SAMPLE))
+        result = await client.consultar_ncm("99999999")
+        assert result is None
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_strips_whitespace(self) -> None:
+        _reset_cache()
+        respx.get(NCM_BASE_URL).mock(return_value=httpx.Response(200, json=_NCM_SAMPLE))
+        result = await client.consultar_ncm("  01031000  ")
+        assert result is not None
+        assert result.codigo == "01031000"

--- a/tests/data/siscomex/test_client.py
+++ b/tests/data/siscomex/test_client.py
@@ -16,28 +16,30 @@ from mcp_brasil.data.siscomex import client
 from mcp_brasil.data.siscomex.constants import NCM_BASE_URL
 from mcp_brasil.data.siscomex.schemas import NcmItem
 
-_NCM_SAMPLE: list[dict] = [
-    {
-        "codigo": "01031000",
-        "descricao": "Reprodutores de raça pura",
-        "dataUltimaAlteracao": "2024-01-01",
-        "dataInicio": "2022-01-01",
-        "dataFim": None,
-        "tipoOrgaoAtoIni": "Resolução",
-        "numeroAtoIni": "123",
-        "anoAtoIni": 2022,
-    },
-    {
-        "codigo": "01039000",
-        "descricao": "Outros suínos vivos",
-        "dataUltimaAlteracao": "2020-01-01",
-        "dataInicio": "2019-01-01",
-        "dataFim": "2021-12-31",
-        "tipoOrgaoAtoIni": None,
-        "numeroAtoIni": None,
-        "anoAtoIni": None,
-    },
-]
+_NCM_SAMPLE: dict = {
+    "Data_Ultima_Atualizacao_NCM": "Vigente em 11/05/2026",
+    "Ato": "Resolução Gecex nº 812/2025",
+    "Nomenclaturas": [
+        {
+            "Codigo": "01031000",
+            "Descricao": "Reprodutores de raça pura",
+            "Data_Inicio": "01/01/2022",
+            "Data_Fim": "31/12/9999",
+            "Tipo_Ato_Ini": "Resolução",
+            "Numero_Ato_Ini": "123",
+            "Ano_Ato_Ini": "2022",
+        },
+        {
+            "Codigo": "01039000",
+            "Descricao": "Outros suínos vivos",
+            "Data_Inicio": "01/01/2019",
+            "Data_Fim": "31/12/2021",
+            "Tipo_Ato_Ini": None,
+            "Numero_Ato_Ini": None,
+            "Ano_Ato_Ini": None,
+        },
+    ],
+}
 
 
 def _reset_cache() -> None:
@@ -75,7 +77,7 @@ class TestFetchAll:
         assert len(result) == 2
         assert result[0].codigo == "01031000"
         assert result[0].descricao == "Reprodutores de raça pura"
-        assert result[1].dataFim == "2021-12-31"
+        assert result[1].dataFim == "31/12/2021"
 
     @pytest.mark.asyncio
     @respx.mock

--- a/tests/data/siscomex/test_integration.py
+++ b/tests/data/siscomex/test_integration.py
@@ -1,0 +1,32 @@
+"""Integration tests for the Siscomex feature using fastmcp.Client.
+
+These tests verify the full pipeline: server registration and tool execution.
+"""
+
+import pytest
+from fastmcp import Client
+
+from mcp_brasil.data.siscomex.server import mcp
+
+
+class TestToolsRegistered:
+    @pytest.mark.asyncio
+    async def test_all_tools_registered(self) -> None:
+        async with Client(mcp) as c:
+            tool_list = await c.list_tools()
+            names = {t.name for t in tool_list}
+            expected = {"buscar_ncm", "consultar_ncm"}
+            assert expected.issubset(names), f"Missing: {expected - names}"
+
+    @pytest.mark.asyncio
+    async def test_tools_have_docstrings(self) -> None:
+        async with Client(mcp) as c:
+            tool_list = await c.list_tools()
+            for tool in tool_list:
+                assert tool.description, f"Tool {tool.name} has no description"
+
+    @pytest.mark.asyncio
+    async def test_tool_count(self) -> None:
+        async with Client(mcp) as c:
+            tool_list = await c.list_tools()
+            assert len(tool_list) == 2

--- a/tests/data/siscomex/test_tools.py
+++ b/tests/data/siscomex/test_tools.py
@@ -1,0 +1,162 @@
+"""Tests for the Siscomex tool functions.
+
+Tools are tested by mocking client functions (never HTTP).
+Context is mocked via MagicMock with async methods.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from mcp_brasil.data.siscomex import tools
+from mcp_brasil.data.siscomex.schemas import NcmItem
+
+CLIENT_MODULE = "mcp_brasil.data.siscomex.client"
+
+
+def _mock_ctx() -> MagicMock:
+    ctx = MagicMock()
+    ctx.info = AsyncMock()
+    ctx.warning = AsyncMock()
+    return ctx
+
+
+# ---------------------------------------------------------------------------
+# buscar_ncm
+# ---------------------------------------------------------------------------
+
+
+class TestBuscarNcm:
+    @pytest.mark.asyncio
+    async def test_formats_results_as_table(self) -> None:
+        items = [
+            NcmItem(
+                codigo="01031000",
+                descricao="Reprodutores de raça pura",
+                dataInicio="2022-01-01",
+            )
+        ]
+        ctx = _mock_ctx()
+        with patch(
+            f"{CLIENT_MODULE}.buscar_ncm",
+            new_callable=AsyncMock,
+            return_value=items,
+        ):
+            result = await tools.buscar_ncm("reprod", ctx)
+        assert "01031000" in result
+        assert "Reprodutores" in result
+
+    @pytest.mark.asyncio
+    async def test_empty_results_message(self) -> None:
+        ctx = _mock_ctx()
+        with patch(
+            f"{CLIENT_MODULE}.buscar_ncm",
+            new_callable=AsyncMock,
+            return_value=[],
+        ):
+            result = await tools.buscar_ncm("xyz123", ctx)
+        assert "Nenhum" in result
+        assert "xyz123" in result
+
+    @pytest.mark.asyncio
+    async def test_max_results_note_when_50(self) -> None:
+        items = [NcmItem(codigo=str(i).zfill(8), descricao=f"Item {i}") for i in range(50)]
+        ctx = _mock_ctx()
+        with patch(
+            f"{CLIENT_MODULE}.buscar_ncm",
+            new_callable=AsyncMock,
+            return_value=items,
+        ):
+            result = await tools.buscar_ncm("item", ctx)
+        assert "máximo 50" in result
+
+    @pytest.mark.asyncio
+    async def test_truncates_long_description(self) -> None:
+        long_desc = "A" * 100
+        items = [NcmItem(codigo="12345678", descricao=long_desc)]
+        ctx = _mock_ctx()
+        with patch(
+            f"{CLIENT_MODULE}.buscar_ncm",
+            new_callable=AsyncMock,
+            return_value=items,
+        ):
+            result = await tools.buscar_ncm("1234", ctx)
+        assert "..." in result
+
+
+# ---------------------------------------------------------------------------
+# consultar_ncm
+# ---------------------------------------------------------------------------
+
+
+class TestConsultarNcm:
+    @pytest.mark.asyncio
+    async def test_formats_found_item(self) -> None:
+        item = NcmItem(
+            codigo="01031000",
+            descricao="Reprodutores de raça pura",
+            dataInicio="2022-01-01",
+            dataFim=None,
+            dataUltimaAlteracao="2024-01-01",
+            tipoOrgaoAtoIni="Resolução",
+            numeroAtoIni="123",
+            anoAtoIni=2022,
+        )
+        ctx = _mock_ctx()
+        with patch(
+            f"{CLIENT_MODULE}.consultar_ncm",
+            new_callable=AsyncMock,
+            return_value=item,
+        ):
+            result = await tools.consultar_ncm("01031000", ctx)
+        assert "01031000" in result
+        assert "Reprodutores" in result
+        assert "Resolução nº 123/2022" in result
+        assert "Em vigor" in result
+
+    @pytest.mark.asyncio
+    async def test_shows_end_date_when_expired(self) -> None:
+        item = NcmItem(
+            codigo="01039000",
+            descricao="Outros suínos",
+            dataInicio="2019-01-01",
+            dataFim="2021-12-31",
+        )
+        ctx = _mock_ctx()
+        with patch(
+            f"{CLIENT_MODULE}.consultar_ncm",
+            new_callable=AsyncMock,
+            return_value=item,
+        ):
+            result = await tools.consultar_ncm("01039000", ctx)
+        assert "2021-12-31" in result
+        assert "Em vigor" not in result
+
+    @pytest.mark.asyncio
+    async def test_not_found_message(self) -> None:
+        ctx = _mock_ctx()
+        with patch(
+            f"{CLIENT_MODULE}.consultar_ncm",
+            new_callable=AsyncMock,
+            return_value=None,
+        ):
+            result = await tools.consultar_ncm("99999999", ctx)
+        assert "não encontrado" in result
+        assert "99999999" in result
+
+    @pytest.mark.asyncio
+    async def test_missing_legal_act_shows_dash(self) -> None:
+        item = NcmItem(
+            codigo="01031000",
+            descricao="Reprodutores de raça pura",
+        )
+        ctx = _mock_ctx()
+        with patch(
+            f"{CLIENT_MODULE}.consultar_ncm",
+            new_callable=AsyncMock,
+            return_value=item,
+        ):
+            result = await tools.consultar_ncm("01031000", ctx)
+        assert "**Ato legal:** —" in result

--- a/tests/test_root_server.py
+++ b/tests/test_root_server.py
@@ -4,10 +4,12 @@ Tests the fully composed server with all features mounted.
 MCP_BRASIL_TOOL_SEARCH=none is set in conftest.py (before any import).
 """
 
-import pytest
-from fastmcp import Client
+import json
 
-from mcp_brasil.server import mcp
+import pytest
+from fastmcp import Client, FastMCP
+
+from mcp_brasil.server import RequestLoggingMiddleware, mcp
 
 
 class TestRootServerTools:
@@ -178,6 +180,56 @@ class TestRootServerAuth:
         from mcp_brasil.server import auth as root_auth
 
         assert root_auth is None
+
+
+class TestMiddlewareStringCoercion:
+    """RequestLoggingMiddleware coerces JSON string params before Pydantic validation."""
+
+    @pytest.mark.asyncio
+    async def test_arguments_string_coerced_to_dict(self) -> None:
+        """Middleware coerces 'arguments' JSON string → dict for call_tool-like tools."""
+        app = FastMCP("test")
+        app.add_middleware(RequestLoggingMiddleware())
+        received: dict = {}
+
+        @app.tool()
+        async def echo_args(arguments: dict) -> str:
+            received.update(arguments)
+            return "ok"
+
+        async with Client(app) as c:
+            result = await c.call_tool("echo_args", {"arguments": '{"key": "value"}'})
+            assert result.data == "ok"
+            assert received == {"key": "value"}
+
+    @pytest.mark.asyncio
+    async def test_arguments_invalid_json_string_passes_through(self) -> None:
+        """Invalid JSON string is not silently swallowed — Pydantic rejects it."""
+        app = FastMCP("test")
+        app.add_middleware(RequestLoggingMiddleware())
+
+        @app.tool()
+        async def echo_args(arguments: dict) -> str:
+            return "ok"
+
+        async with Client(app) as c:
+            with pytest.raises(Exception, match="Input should be a valid dictionary"):
+                await c.call_tool("echo_args", {"arguments": "nao-e-json"})
+
+    @pytest.mark.asyncio
+    async def test_consultas_string_coerced_to_list(self) -> None:
+        """Middleware coerces 'consultas' JSON string → list for executar_lote."""
+        consultas_json = json.dumps([{"tool": "listar_features", "args": {}}])
+        async with Client(mcp) as c:
+            result = await c.call_tool("executar_lote", {"consultas": consultas_json})
+            assert result.data
+
+    @pytest.mark.asyncio
+    async def test_consultas_invalid_json_string_passes_through(self) -> None:
+        """Invalid JSON string for 'consultas' is not silently swallowed — Pydantic rejects it."""
+        async with Client(mcp) as c:
+            with pytest.raises(Exception, match="Input should be a valid list"):
+                await c.call_tool("executar_lote", {"consultas": "nao-e-json"})
 
 
 class TestRootServerToolTags:

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.10"
 
 [[package]]
@@ -500,6 +500,39 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/ac/97/a538654732974a94ff96c1db621fa464f455c02d4bb7d2652f4edc21d600/cryptography-46.0.5-pp311-pypy311_pp73-manylinux_2_34_aarch64.whl", hash = "sha256:d861ee9e76ace6cf36a6a89b959ec08e7bc2493ee39d07ffe5acb23ef46d27da", size = 4217990, upload-time = "2026-02-10T19:18:25.957Z" },
     { url = "https://files.pythonhosted.org/packages/ae/11/7e500d2dd3ba891197b9efd2da5454b74336d64a7cc419aa7327ab74e5f6/cryptography-46.0.5-pp311-pypy311_pp73-manylinux_2_34_x86_64.whl", hash = "sha256:2b7a67c9cd56372f3249b39699f2ad479f6991e62ea15800973b956f4b73e257", size = 4381252, upload-time = "2026-02-10T19:18:27.496Z" },
     { url = "https://files.pythonhosted.org/packages/bc/58/6b3d24e6b9bc474a2dcdee65dfd1f008867015408a271562e4b690561a4d/cryptography-46.0.5-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:8456928655f856c6e1533ff59d5be76578a7157224dbd9ce6872f25055ab9ab7", size = 3407605, upload-time = "2026-02-10T19:18:29.233Z" },
+]
+
+[[package]]
+name = "curl-cffi"
+version = "0.15.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "cffi" },
+    { name = "rich" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/48/5b/89fcfebd3e5e85134147ac99e9f2b2271165fd4d71984fc65da5f17819b7/curl_cffi-0.15.0.tar.gz", hash = "sha256:ea0c67652bf6893d34ee0f82c944f37e488f6147e9421bef1771cc6545b02ded", size = 196437, upload-time = "2026-04-03T11:12:31.525Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5e/42/54ddd442c795f30ce5dd4e49f87ce77505958d3777cd96a91567a3975d2a/curl_cffi-0.15.0-cp310-abi3-macosx_10_9_x86_64.whl", hash = "sha256:bda66404010e9ed743b1b83c20c86f24fe21a9a6873e17479d6e67e29d8ded28", size = 2795267, upload-time = "2026-04-03T11:11:46.48Z" },
+    { url = "https://files.pythonhosted.org/packages/83/2d/3915e238579b3c5a92cead5c79130c3b8d20caaba7616cc4d894650e1d6b/curl_cffi-0.15.0-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:a25620d9bf989c9c029a7d1642999c4c265abb0bad811deb2f77b0b5b2b12e5b", size = 2573544, upload-time = "2026-04-03T11:11:47.951Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/b3/9d2f1057749a1b07ba1989db3c1503ce8bed998310bae9aea2c43aa64f20/curl_cffi-0.15.0-cp310-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:582e570aa2586b96ed47cf4a17586b9a3c462cbe43f780487c3dc245c6ef1527", size = 10515369, upload-time = "2026-04-03T11:11:50.126Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/1d/6d10dded5ce3fd8157e558ebd97d09e551b77a62cdc1c31e93d0a633cee5/curl_cffi-0.15.0-cp310-abi3-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:838e48212447d9c81364b04707a5c861daf08f8320f9ecb3406a8919d1d5c3b3", size = 10160045, upload-time = "2026-04-03T11:11:52.664Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/12/c70b835487ace3b9ba1502631912e3440082b8ae3a162f60b59cb0b6444d/curl_cffi-0.15.0-cp310-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:2b6c847d86283b07ae69bb72c82eb8a59242277142aa35b89850f89e792a02fc", size = 11090433, upload-time = "2026-04-03T11:11:55.049Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/0d/78edcc4f71934225db99df68197a107386d59080742fc7bf6bb4d007924f/curl_cffi-0.15.0-cp310-abi3-manylinux_2_28_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:9e5e69eee735f659287e2c84444319d68a1fa68dd37abf228943a4074864283a", size = 10479178, upload-time = "2026-04-03T11:11:57.685Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/84/1e101c1acb1ea2f0b4992f5c3024f596d8e21db0d53540b9d583f673c4e7/curl_cffi-0.15.0-cp310-abi3-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:aa1323950224db24f4c510d010b3affa02196ca853fb424191fa917a513d3f4b", size = 10317051, upload-time = "2026-04-03T11:12:00.295Z" },
+    { url = "https://files.pythonhosted.org/packages/28/42/8ef236b22a6c23d096c85a1dc507efe37bfdfc7a2f8a4b34efb590197369/curl_cffi-0.15.0-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:41f80170ba844009273b2660da1964ec31e99e5719d16b3422ada87177e32e13", size = 11299660, upload-time = "2026-04-03T11:12:02.791Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/01/56aeb055d962da87a1be0d74c6c644e251c7e88129b5471dc44ac724e678/curl_cffi-0.15.0-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:1977e1e12cfb5c11352cbb74acef1bed24eb7d226dab61ca57c168c21acd4d61", size = 11945049, upload-time = "2026-04-03T11:12:05.912Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/8c/2abf99a38d6340d66cf0557e0c750ef3f8883dfc5d450087e01c85861343/curl_cffi-0.15.0-cp310-abi3-win_amd64.whl", hash = "sha256:5a0c1896a0d5a5ac1eb89cd24b008d2b718dd1df6fd2f75451b59ca66e49e572", size = 1661649, upload-time = "2026-04-03T11:12:07.948Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/39/dfd54f2240d3a9b96d77bacc62b97813b35e2aa8ecf5cd5013c683f1ba96/curl_cffi-0.15.0-cp310-abi3-win_arm64.whl", hash = "sha256:a6d57f8389273a3a1f94370473c74897467bcc36af0a17336989780c507fa43d", size = 1410741, upload-time = "2026-04-03T11:12:10.073Z" },
+    { url = "https://files.pythonhosted.org/packages/19/6a/c24df8a4fc22fa84070dcd94abeba43c15e08cc09e35869565c0bad196fd/curl_cffi-0.15.0-cp313-abi3-android_24_arm64_v8a.whl", hash = "sha256:4682dc38d4336e0eb0b185374db90a760efde63cbea994b4e63f3521d44c4c92", size = 7190427, upload-time = "2026-04-03T11:12:12.142Z" },
+    { url = "https://files.pythonhosted.org/packages/11/56/132225cb3491d07cc6adcce5fe395e059bde87c68cff1ef87a31c88c7819/curl_cffi-0.15.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:967ad7355bd8e9586f8c2d02eaa99953747549e7ea4a9b25cd53353e6b67fe6d", size = 2795723, upload-time = "2026-04-03T11:12:13.668Z" },
+    { url = "https://files.pythonhosted.org/packages/07/8f/f4f83cd303bef7e8f1749512e5dd157e7e5d08b0a36c8211f9640a2757bf/curl_cffi-0.15.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7e63539d0d839d0a8c5eacf86229bc68c57803547f35e0db7ee0986328b478c3", size = 2573739, upload-time = "2026-04-03T11:12:15.08Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/5c/643d65c7fc9acd742876aa55c2d7823c438cb7665810acd2e66c9976c4d9/curl_cffi-0.15.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:08c799b89740b9bc49c09fbc3d5907f13ac1f845ca52620507ef9466d4639dd5", size = 10521046, upload-time = "2026-04-03T11:12:17.034Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/0b/9b8037113c93f4c5323096163471fa7c35c7676c3f608eeaf1287cd99d58/curl_cffi-0.15.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7b7a92767a888ee90147e18964b396d8435ff42737030d6fb00824ffd6094805", size = 11096115, upload-time = "2026-04-03T11:12:19.694Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/96/fff2fcbd924ef4042e0d67379f751a8a4e3186a91e75e35a4cf218b306ee/curl_cffi-0.15.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:829cc357061ecb99cc2d406301f609a039e05665322f5c025ec67c38b0dc49ce", size = 11305346, upload-time = "2026-04-03T11:12:22.151Z" },
+    { url = "https://files.pythonhosted.org/packages/53/1b/304b253a45ab28691c8c5e8cca1e6cbb9cf8e46dfceae4648dd536f75e73/curl_cffi-0.15.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:408d6f14e346841cd889c2e0962832bb235ba3b6749ebf609f347f747da5e60f", size = 11949834, upload-time = "2026-04-03T11:12:24.986Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/ff/4723d92f08259c707a974aba27a08d0a822b9555e35ca581bf18d055a364/curl_cffi-0.15.0-cp314-cp314t-win_amd64.whl", hash = "sha256:b624c7ce087bfda967a013ed0a64702a525444e5b6e97d23534d567ccc6525aa", size = 1702771, upload-time = "2026-04-03T11:12:28.201Z" },
+    { url = "https://files.pythonhosted.org/packages/59/8c/36bbe06d66fa2b765e4a07199f643a59a9cd1a754207a96335402a9520f4/curl_cffi-0.15.0-cp314-cp314t-win_arm64.whl", hash = "sha256:0b6c0543b993996670e9e4b78e305a2d60809d5681903ffb5568e21a387434d3", size = 1466312, upload-time = "2026-04-03T11:12:30.054Z" },
 ]
 
 [[package]]
@@ -1429,6 +1462,7 @@ source = { editable = "." }
 dependencies = [
     { name = "anthropic" },
     { name = "beautifulsoup4" },
+    { name = "curl-cffi" },
     { name = "duckdb" },
     { name = "fastmcp", extra = ["code-mode"] },
     { name = "httpx" },
@@ -1467,6 +1501,7 @@ requires-dist = [
     { name = "anthropic", specifier = ">=0.40" },
     { name = "anthropic", marker = "extra == 'llm'", specifier = ">=0.40" },
     { name = "beautifulsoup4", specifier = ">=4.12" },
+    { name = "curl-cffi", specifier = ">=0.15.0" },
     { name = "duckdb", specifier = ">=1.1" },
     { name = "fastmcp", extras = ["code-mode"], specifier = ">=3.2.3" },
     { name = "fastmcp", extras = ["code-mode"], marker = "extra == 'code-mode'" },


### PR DESCRIPTION
## 1. fix(server) — Tolerância a `arguments` como string JSON

### Problema

Modelos como Qwen3.5 (FP8/SGLang) serializam argumentos dict/list como string JSON em vez de objeto literal. Com `temperature=0`, isso causa loop infinito de `ValidationError` — o modelo recebe o erro, tenta novamente com o mesmo formato, e nunca sai.

Dois pontos de falha distintos:

1. **`executar_lote` — campo `args`** (`batch.py`): quando o modelo passa `"args": "{\"ano\": 2026}"` em vez de `"args": {"ano": 2026}`.
2. **`brasil_call_tool` (BM25SearchTransform) — campos `arguments` e `consultas`** (`server.py`): quando o middleware recebe os campos como string JSON antes da validação Pydantic.

### Solução

- `batch.py` (`_run_one`): coerce `args: str → json.loads()` antes do dispatch; retorna erro descritivo se o JSON for inválido ou tipo errado.
- `server.py` (`RequestLoggingMiddleware.on_call_tool`): coerce `arguments` e `consultas` in-place antes da validação Pydantic; JSON inválido passa adiante e é rejeitado normalmente pelo Pydantic.

### Testes

- `TestExecuteBatchStringArgs` (3 casos): args como string válida, JSON inválido, tipo errado (lista).
- `TestMiddlewareStringCoercion` (4 casos): `arguments` string → dict, `arguments` JSON inválido passa adiante, `consultas` string → lista, `consultas` JSON inválido passa adiante.

Closes #8

---

## 2. feat(comercio-exterior) — Siscomex NCM + ComexStat

Implementa as tools solicitadas na issue #13.

**Módulo `siscomex`:**
| Tool | Descrição |
|---|---|
| `siscomex_buscar_ncm` | Busca por código parcial ou descrição (cache TTL 24h) |
| `siscomex_consultar_ncm` | Detalhe de código NCM de 8 dígitos |

**Módulo `comexstat`:**
| Tool | Descrição |
|---|---|
| `comexstat_consultar_exportacoes` | Exportações brasileiras por período, NCM e país |
| `comexstat_consultar_importacoes` | Importações brasileiras por período, NCM e país |
| `comexstat_balanca_comercial` | FOB exportações − FOB importações por período |
| `comexstat_listar_paises` | Lista países disponíveis (id + nome) |

**Escopo da issue #13:**
| Tool solicitada | Status |
|---|---|
| `get_ncm` | implementado |
| `get_exportacoes` | implementado |
| `get_importacoes` | implementado |
| `get_balanca_comercial` | implementado |
| `get_tratamento_administrativo` | requer certificado digital ICP-Brasil (mTLS) — sem alternativa via login gratuito |
| `get_catalogo_produtos` | requer certificado digital ICP-Brasil (mTLS) — sem alternativa via login gratuito |

Closes #13

---

## 3. fix(comercio-exterior) — Correções da API real

Descobertas durante testes ao vivo após a implementação inicial.

**Siscomex:**
- Resposta real é `{"Nomenclaturas": [...]}` (dict, não lista) com campos PascalCase (`Codigo`, `Descricao`, `Data_Inicio`, `Data_Fim`, etc.)
- `dataFim: "31/12/9999"` normalizado para `None` (= em vigor)

**ComexStat:**
- Endpoint corrigido: `/general/query` → `/general` (caminho antigo retorna "No route found")
- Campos corrigidos: `year`, `monthNumber`, `country`, `ncm`, `metricFOB`, `metricKG`
- `listar_paises`: resposta é `{"data": [[{"id": ..., "text": ...}]]}` (lista de listas)
- **Bypass Cloudflare WAF**: `httpx` substituído por `curl_cffi` (`impersonate="chrome124"`) no `POST /general` — Cloudflare bloqueia fingerprint TLS (JA3) não-browser
- **Rate limit**: `balanca_comercial` chama export + import sequencialmente com `asyncio.sleep(3)` entre eles; `_query` faz retry automático após 12s em HTTP 429

---

## CI
- 60/60 testes passando
- mypy strict limpo
- ruff limpo