### PR TITLE
fix(server): tolerate JSON-string arguments in executar_lote and call_tool

### DIFF
--- a/src/mcp_brasil/_shared/tolerant_args.py
+++ b/src/mcp_brasil/_shared/tolerant_args.py
@@ -1,0 +1,64 @@
+"""Tolerância a argumentos enviados como string JSON nas meta-tools.
+
+Alguns modelos (ex.: Qwen) serializam campos de objeto/array como string JSON em
+vez de objeto/array. Sem tratamento, a validação Pydantic rejeita e agentes com
+amostragem determinística (temperature=0) entram em loop de retry com o mesmo erro.
+
+A normalização roda no middleware `on_call_tool`, que executa ANTES da validação
+dos argumentos do tool (o que ele alterar em `context.message.arguments` segue para
+a execução). Só uma allowlist exata de (tool, campo, tipo esperado) é tratada —
+nunca coerção genérica, que mudaria a semântica de campos textuais legítimos cujo
+conteúdo por acaso é JSON válido (ex.: "2024", "true", "[]").
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import mcp.types as mt
+from fastmcp.server.middleware import CallNext, Middleware, MiddlewareContext
+from fastmcp.tools import ToolResult
+
+# Tool name -> {campo: tipo Python esperado após json.loads}.
+# Apenas estes campos, nestas tools, são tolerantes a string JSON.
+_JSON_STRING_FIELDS: dict[str, dict[str, type]] = {
+    "executar_lote": {"consultas": list},
+    "call_tool": {"arguments": dict},
+}
+
+
+def normalize_json_string_args(name: str, arguments: dict[str, Any] | None) -> None:
+    """Converte, no lugar, campos string-JSON da allowlist para o objeto/array.
+
+    Só altera quando o valor é `str`, faz `json.loads` sem erro, e o resultado bate
+    com o tipo esperado. Caso contrário, deixa intacto — a validação normal do tool
+    decide (e recusa entradas realmente inválidas).
+    """
+    if not arguments:
+        return
+    fields = _JSON_STRING_FIELDS.get(name)
+    if fields is None:
+        return
+    for field, expected_type in fields.items():
+        value = arguments.get(field)
+        if not isinstance(value, str):
+            continue
+        try:
+            parsed = json.loads(value)
+        except (ValueError, TypeError):
+            continue  # não é JSON válido -> deixa a validação normal recusar
+        if isinstance(parsed, expected_type):
+            arguments[field] = parsed
+
+
+class TolerantArgumentsMiddleware(Middleware):
+    """Aceita `consultas`/`arguments` como objeto/array OU string JSON nas meta-tools."""
+
+    async def on_call_tool(
+        self,
+        context: MiddlewareContext[mt.CallToolRequestParams],
+        call_next: CallNext[mt.CallToolRequestParams, ToolResult],
+    ) -> ToolResult:
+        normalize_json_string_args(context.message.name, context.message.arguments)
+        return await call_next(context)

--- a/src/mcp_brasil/server.py
+++ b/src/mcp_brasil/server.py
@@ -26,6 +26,7 @@ from ._shared.auth import build_auth
 from ._shared.batch import build_dispatch, execute_batch
 from ._shared.feature import FeatureRegistry
 from ._shared.lifespan import http_lifespan
+from ._shared.tolerant_args import TolerantArgumentsMiddleware
 from .settings import MCP_BRASIL_BASE_URL, TOOL_SEARCH
 
 logging.basicConfig(
@@ -99,6 +100,8 @@ mcp = FastMCP(
 
 # Add middleware
 mcp.add_middleware(RequestLoggingMiddleware())
+# Tolera `consultas`/`arguments` enviados como string JSON (ver _shared/tolerant_args.py)
+mcp.add_middleware(TolerantArgumentsMiddleware())
 
 
 # Health check endpoint (no auth required)

--- a/tests/_shared/test_tolerant_args.py
+++ b/tests/_shared/test_tolerant_args.py
@@ -2,6 +2,8 @@
 
 import json
 
+import pytest
+
 from mcp_brasil._shared.tolerant_args import normalize_json_string_args
 
 
@@ -69,3 +71,31 @@ class TestSeguranca:
         args: dict[str, object] = {}
         normalize_json_string_args("executar_lote", args)
         assert args == {}
+
+
+class TestCallToolE2E:
+    """e2e do caminho `call_tool` (transform BM25) com `arguments` como string JSON."""
+
+    @pytest.mark.asyncio
+    async def test_call_tool_aceita_arguments_string_json(self) -> None:
+        from fastmcp import Client, Context, FastMCP
+        from fastmcp.server.transforms.search import BM25SearchTransform
+
+        from mcp_brasil._shared.tolerant_args import TolerantArgumentsMiddleware
+
+        mcp = FastMCP("test-call-tool")
+        mcp.add_middleware(TolerantArgumentsMiddleware())
+
+        @mcp.tool
+        async def eco(valor: str, ctx: Context) -> str:
+            return f"eco:{valor}"
+
+        mcp.add_transform(BM25SearchTransform(max_results=5, always_visible=["eco"]))
+
+        async with Client(mcp) as c:
+            result = await c.call_tool(
+                "call_tool",
+                {"name": "eco", "arguments": json.dumps({"valor": "oi"})},
+            )
+        # Sem a normalização, `arguments` (string) seria rejeitado por validação.
+        assert "eco:oi" in str(result.data)

--- a/tests/_shared/test_tolerant_args.py
+++ b/tests/_shared/test_tolerant_args.py
@@ -1,0 +1,71 @@
+"""Testes do normalizador de argumentos string-JSON (issue #8)."""
+
+import json
+
+from mcp_brasil._shared.tolerant_args import normalize_json_string_args
+
+
+class TestExecutarLoteConsultas:
+    def test_json_string_vira_lista(self) -> None:
+        consultas = [{"tool": "camara_despesas_deputado", "args": {"ano": 2024}}]
+        args = {"consultas": json.dumps(consultas)}
+        normalize_json_string_args("executar_lote", args)
+        assert args["consultas"] == consultas
+
+    def test_lista_permanece_intacta(self) -> None:
+        consultas = [{"tool": "x", "args": {}}]
+        args = {"consultas": consultas}
+        normalize_json_string_args("executar_lote", args)
+        assert args["consultas"] is consultas
+
+    def test_json_object_nao_e_coagido(self) -> None:
+        # string JSON que parseia para dict (não list) -> não altera
+        args = {"consultas": json.dumps({"tool": "x"})}
+        normalize_json_string_args("executar_lote", args)
+        assert isinstance(args["consultas"], str)
+
+
+class TestCallToolArguments:
+    def test_json_string_vira_dict(self) -> None:
+        inner = {"codigo": 35, "ano": 2024}
+        args = {"name": "ibge_listar_estados", "arguments": json.dumps(inner)}
+        normalize_json_string_args("call_tool", args)
+        assert args["arguments"] == inner
+
+    def test_dict_permanece_intacto(self) -> None:
+        inner = {"a": 1}
+        args = {"name": "t", "arguments": inner}
+        normalize_json_string_args("call_tool", args)
+        assert args["arguments"] is inner
+
+    def test_json_array_nao_e_coagido(self) -> None:
+        # string JSON que parseia para list (não dict) -> não altera
+        args = {"name": "t", "arguments": json.dumps([1, 2])}
+        normalize_json_string_args("call_tool", args)
+        assert isinstance(args["arguments"], str)
+
+
+class TestSeguranca:
+    def test_json_invalido_intacto(self) -> None:
+        args = {"consultas": "not json {"}
+        normalize_json_string_args("executar_lote", args)
+        assert args["consultas"] == "not json {"
+
+    def test_tool_fora_da_allowlist_intacta(self) -> None:
+        args = {"arguments": json.dumps({"a": 1})}
+        normalize_json_string_args("alguma_outra_tool", args)
+        assert isinstance(args["arguments"], str)
+
+    def test_campo_fora_da_allowlist_intacto(self) -> None:
+        # string JSON legítima num campo não-allowlisted da tool allowlisted
+        args = {"consultas": [{"tool": "x"}], "outro": json.dumps([1, 2])}
+        normalize_json_string_args("executar_lote", args)
+        assert isinstance(args["outro"], str)
+
+    def test_arguments_none_nao_levanta(self) -> None:
+        normalize_json_string_args("executar_lote", None)
+
+    def test_arguments_vazio_nao_levanta(self) -> None:
+        args: dict[str, object] = {}
+        normalize_json_string_args("executar_lote", args)
+        assert args == {}

--- a/tests/test_root_server.py
+++ b/tests/test_root_server.py
@@ -4,6 +4,8 @@ Tests the fully composed server with all features mounted.
 MCP_BRASIL_TOOL_SEARCH=none is set in conftest.py (before any import).
 """
 
+import json
+
 import pytest
 from fastmcp import Client
 
@@ -166,6 +168,18 @@ class TestExecutarLote:
             tool = next(t for t in tools if t.name == "executar_lote")
             assert tool.description
             assert "paralelo" in tool.description.lower()
+
+    @pytest.mark.asyncio
+    async def test_aceita_consultas_como_string_json(self) -> None:
+        # Issue #8: modelos que serializam `consultas` como string JSON não devem
+        # ser rejeitados por erro de validação — a string é normalizada antes.
+        consultas = [{"tool": "tool_inexistente", "args": {}}]
+        async with Client(mcp) as c:
+            result = await c.call_tool(
+                "executar_lote", {"consultas": json.dumps(consultas)}
+            )
+        # O lote roda (sem ValidationError); a tool inexistente vira mensagem no resultado.
+        assert result.data is not None
 
 
 class TestRootServerAuth:

--- a/tests/test_root_server.py
+++ b/tests/test_root_server.py
@@ -175,9 +175,7 @@ class TestExecutarLote:
         # ser rejeitados por erro de validação — a string é normalizada antes.
         consultas = [{"tool": "tool_inexistente", "args": {}}]
         async with Client(mcp) as c:
-            result = await c.call_tool(
-                "executar_lote", {"consultas": json.dumps(consultas)}
-            )
+            result = await c.call_tool("executar_lote", {"consultas": json.dumps(consultas)})
         # O lote roda (sem ValidationError); a tool inexistente vira mensagem no resultado.
         assert result.data is not None
 


### PR DESCRIPTION
## O que isto resolve

Issue #8: as meta-tools `executar_lote` (campo `consultas`) e `call_tool` (campo
`arguments`) rejeitavam o campo quando um modelo o enviava como string JSON em vez
de objeto/array, com erro de validação Pydantic. Com amostragem determinística
(temperature=0), o agente reincidia no mesmo erro e entrava em loop de retry.

## Correção

Um middleware `on_call_tool` (`_shared/tolerant_args.py`) normaliza, ANTES da
validação, apenas uma allowlist exata de (tool, campo, tipo esperado):

- `executar_lote.consultas` -> aceita `list` ou string JSON que parseia para `list`
- `call_tool.arguments` -> aceita `dict` ou string JSON que parseia para `dict`

Só altera quando o valor e `str`, o `json.loads` tem sucesso e o tipo bate; caso
contrario deixa intacto (a validacao normal recusa entradas invalidas). Nao ha
coercao generica: uma string textual legitima que por acaso seja JSON valido
(`"2024"`, `"true"`, `"[]"`) nao e tocada.

Sobre o mecanismo: a issue sugere um `field_validator` Pydantic. Isso cobriria
`executar_lote` (definida aqui), mas nao `call_tool`, que vem da transform BM25 do
FastMCP e nao tem schema editavel no projeto. O middleware `on_call_tool` roda antes
da validacao para as duas, sendo o ponto comum minimo. A classe fica em `_shared/`;
o `server.py` ganha apenas o registro (1 linha), ao lado do `RequestLoggingMiddleware`
ja existente.

## Verificação

- `tests/_shared/test_tolerant_args.py`: 11 testes do normalizador (allowlist, tipo
  esperado, JSON invalido, campos/tools fora da lista, backward-compat).
- `tests/test_root_server.py::TestExecutarLote`: e2e via `fastmcp.Client` chamando
  `executar_lote` com `consultas` como string JSON.
- Reproducao isolada: antes do fix, `consultas` como string JSON falha com
  `ValidationError: Input should be a valid list [input_type=str]`; depois, executa.
- `ruff check`, `ruff format --check` e `mypy` (strict) passam nos arquivos alterados.

---

Disclosure: este PR foi produzido por um pipeline assistido por IA (Claude Opus 4.8).
