### PR TITLE
fix(cache): preserve cached None results

### DIFF
--- a/src/mcp_brasil/_shared/cache.py
+++ b/src/mcp_brasil/_shared/cache.py
@@ -42,7 +42,14 @@ class TTLCache:
         return len(self._store)
 
     def get(self, key: str, default: Any = None) -> Any:
-        """Get a value if it exists and hasn't expired."""
+        """Get a value if it exists and hasn't expired.
+
+        Args:
+            key: Cache key.
+            default: Returned when the key is absent or expired. Pass a unique
+                sentinel to distinguish "not cached" from a cached ``None``;
+                ``None`` alone cannot tell the two apart.
+        """
         entry = self._store.get(key)
         if entry is None:
             return default
@@ -79,6 +86,13 @@ def ttl_cache(ttl: float = 300.0, maxsize: int = 256) -> Callable[[F], F]:
     """Decorator that caches async function results with TTL.
 
     Cache key is built from function name + stringified args/kwargs.
+
+    Every result is cached, **including ``None``** ("negative caching"). This is
+    deliberate: a function that legitimately returns ``None`` should not be
+    re-executed on every call. The trade-off is that a caller which swallows an
+    exception and returns ``None`` will have that failure frozen for ``ttl``
+    seconds. Clients should raise on transport errors rather than returning
+    ``None``, so the failure is never cached in the first place.
 
     Args:
         ttl: Time-to-live in seconds. Default: 300 (5 minutes).

--- a/src/mcp_brasil/_shared/cache.py
+++ b/src/mcp_brasil/_shared/cache.py
@@ -21,6 +21,7 @@ from collections.abc import Callable
 from typing import Any, TypeVar
 
 F = TypeVar("F", bound=Callable[..., Any])
+_MISSING = object()
 
 
 class TTLCache:
@@ -40,15 +41,15 @@ class TTLCache:
         """Number of entries currently in cache (including expired)."""
         return len(self._store)
 
-    def get(self, key: str) -> Any | None:
+    def get(self, key: str, default: Any = None) -> Any:
         """Get a value if it exists and hasn't expired."""
         entry = self._store.get(key)
         if entry is None:
-            return None
+            return default
         expires_at, value = entry
         if time.monotonic() > expires_at:
             del self._store[key]
-            return None
+            return default
         return value
 
     def set(self, key: str, value: Any) -> None:
@@ -97,8 +98,8 @@ def ttl_cache(ttl: float = 300.0, maxsize: int = 256) -> Callable[[F], F]:
         @functools.wraps(func)
         async def wrapper(*args: Any, **kwargs: Any) -> Any:
             key = f"{func.__qualname__}:{args!r}:{kwargs!r}"
-            cached = cache.get(key)
-            if cached is not None:
+            cached = cache.get(key, _MISSING)
+            if cached is not _MISSING:
                 return cached
             result = await func(*args, **kwargs)
             cache.set(key, result)

--- a/tests/_shared/test_cache.py
+++ b/tests/_shared/test_cache.py
@@ -55,6 +55,20 @@ class TestTTLCache:
 
 class TestTtlCacheDecorator:
     @pytest.mark.asyncio
+    async def test_caches_none_result(self) -> None:
+        call_count = 0
+
+        @ttl_cache(ttl=60)
+        async def fetch_optional() -> None:
+            nonlocal call_count
+            call_count += 1
+            return None
+
+        assert await fetch_optional() is None
+        assert await fetch_optional() is None
+        assert call_count == 1
+
+    @pytest.mark.asyncio
     async def test_caches_result(self) -> None:
         call_count = 0
 


### PR DESCRIPTION
## Problema

O decorator `ttl_cache` usava `None` para representar tanto um cache miss quanto um valor armazenado. Com isso, funções assíncronas que retornam `None` eram executadas novamente em todas as chamadas, mesmo dentro do TTL.

Isso é especialmente relevante para consultas opcionais ou APIs que usam `None` para representar ausência de resultado: o cache não evitava chamadas repetidas.

## Correção

- adiciona um sentinel privado `_MISSING` para distinguir cache miss de valor `None`;
- mantém `TTLCache.get(key)` compatível, retornando `None` por padrão quando a chave não existe;
- permite que o decorator recupere corretamente qualquer valor armazenado, inclusive `None`;
- adiciona teste de regressão garantindo que uma função que retorna `None` seja executada apenas uma vez.

## Validação

Antes da correção, o novo teste falhava com:

```text
assert call_count == 1
E assert 2 == 1
```

Depois da correção:

```text
14 passed in tests/_shared/test_cache.py
2548 passed na suíte completa
ruff check: OK
ruff format --check: OK
mypy strict: OK
```