### PR TITLE
fix(batch): tolerar `args` aninhado como string JSON no executar_lote

### DIFF
--- a/src/mcp_brasil/_shared/batch.py
+++ b/src/mcp_brasil/_shared/batch.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import asyncio
 import importlib
 import inspect
+import json
 import logging
 import pkgutil
 from typing import TYPE_CHECKING, Any
@@ -89,6 +90,20 @@ async def execute_batch(
     async def _run_one(q: dict[str, Any]) -> tuple[str, str]:
         tool_name = q.get("tool", "")
         args = q.get("args", {})
+
+        # Alguns modelos serializam `args` como string JSON em vez de objeto
+        # (ver #8). O middleware de tolerant_args cobre os campos de topo do
+        # call_tool/executar_lote, mas nao este `args` aninhado de cada
+        # consulta do lote — sem isto, `fn(**args)` estoura com
+        # "argument after ** must be a mapping, not str".
+        if isinstance(args, str):
+            try:
+                args = json.loads(args)
+            except json.JSONDecodeError as exc:
+                return tool_name, f"'args' não é JSON válido: {exc}"
+        if not isinstance(args, dict):
+            return tool_name, f"'args' deve ser um objeto JSON, recebido: {type(args).__name__}"
+
         fn = _dispatch.get(tool_name)
 
         if fn is None:

--- a/tests/_shared/test_batch.py
+++ b/tests/_shared/test_batch.py
@@ -161,6 +161,67 @@ class TestExecuteBatch:
         assert "Erro" in result
 
 
+class TestExecuteBatchStringArgs:
+    """Cobre o `args` aninhado de cada consulta do lote (issue #8).
+
+    O middleware de `tolerant_args` trata os campos de topo (`arguments` do
+    call_tool, `consultas` do executar_lote); este `args` fica um nivel abaixo
+    e nao e alcancado por ele.
+    """
+
+    def teardown_method(self) -> None:
+        for key in ("feriados", "some_tool", "typed_tool"):
+            batch._dispatch.pop(key, None)
+
+    @pytest.mark.asyncio
+    async def test_args_as_json_string(self) -> None:
+        """String JSON valida deve ser coagida e a tool executar normalmente."""
+
+        async def tool(ano: int) -> str:
+            return f"ano={ano}"
+
+        batch._dispatch["feriados"] = tool
+        ctx = _mock_ctx()
+        result = await batch.execute_batch([{"tool": "feriados", "args": '{"ano": 2026}'}], ctx)
+        assert "ano=2026" in result
+
+    @pytest.mark.asyncio
+    async def test_args_dict_still_works(self) -> None:
+        """Nao-regressao: dict continua sendo o caminho normal, sem coercao."""
+
+        async def tool(ano: int) -> str:
+            return f"ano={ano}"
+
+        batch._dispatch["feriados"] = tool
+        ctx = _mock_ctx()
+        result = await batch.execute_batch([{"tool": "feriados", "args": {"ano": 2026}}], ctx)
+        assert "ano=2026" in result
+
+    @pytest.mark.asyncio
+    async def test_args_invalid_json_string_returns_error(self) -> None:
+        """String invalida vira erro no resultado, nao excecao."""
+
+        async def tool(x: int) -> str:
+            return "ok"
+
+        batch._dispatch["some_tool"] = tool
+        ctx = _mock_ctx()
+        result = await batch.execute_batch([{"tool": "some_tool", "args": "nao-e-json"}], ctx)
+        assert "não é JSON válido" in result
+
+    @pytest.mark.asyncio
+    async def test_args_wrong_type_returns_error(self) -> None:
+        """Tipo invalido (ex: lista) vira erro descritivo, nao excecao."""
+
+        async def tool(x: int) -> str:
+            return "ok"
+
+        batch._dispatch["typed_tool"] = tool
+        ctx = _mock_ctx()
+        result = await batch.execute_batch([{"tool": "typed_tool", "args": [1, 2, 3]}], ctx)
+        assert "deve ser um objeto JSON" in result
+
+
 def _real_registry() -> batch.FeatureRegistry:
     """Build a real registry from the project for integration testing."""
     from mcp_brasil._shared.feature import FeatureRegistry


### PR DESCRIPTION
Closes #8.

## Contexto

A #19 (já mergeada) trata os campos de **topo** via allowlist: `arguments` do
`call_tool` e `consultas` do `executar_lote`. Mas cada consulta dentro do lote
tem um `args` **um nível abaixo**, que o middleware não alcança.

Sem esta PR, um modelo que serializa esse campo como string JSON produz:

```
argument after ** must be a mapping, not str
```

Com as duas juntas, a issue #8 fica coberta ponta a ponta.

## O que faz

Em `_shared/batch.py::_run_one`, antes do dispatch:

- `args` como string JSON válida → `json.loads`;
- string inválida → erro descritivo **no resultado**, não exceção;
- tipo errado (ex: lista) → erro descritivo, não exceção.

## Crédito

O hunk vem da PR #12 de @caiojohnston, extraído em PR própria porque o restante
daquela PR (coerção genérica no `server.py`, features `comexstat` e `siscomex`)
depende de decisões de política e produto que seguem em aberto. A coerção
genérica do `server.py` foi deliberadamente **descartada** em favor da allowlist
da #19 — medindo as duas sobre os mesmos 9 payloads, 7 divergiram e em todos os
7 a versão genérica coagia demais (`'null'`→`None`, `'true'`→`bool`, e texto
literal do usuário que *parece* JSON era convertido silenciosamente).

## Validação

- **2564 passed / 0 failed** (2560 da base + 4 novos)
- `ruff check`, `ruff format --check` e `mypy --strict` verdes
- 4 testes: string JSON válida, **não-regressão do caminho dict**, string
  inválida e tipo errado