### PR TITLE
fix(server): anunciar a versão do pacote no serverInfo

### DIFF
--- a/src/mcp_brasil/server.py
+++ b/src/mcp_brasil/server.py
@@ -22,6 +22,7 @@ from fastmcp.server.middleware import CallNext, Middleware, MiddlewareContext
 from fastmcp.tools import ToolResult
 from starlette.responses import JSONResponse
 
+from . import __version__
 from ._shared.auth import build_auth
 from ._shared.batch import build_dispatch, execute_batch
 from ._shared.feature import FeatureRegistry
@@ -92,6 +93,7 @@ _LOGO_URL = f"{MCP_BRASIL_BASE_URL.rstrip('/')}/logo.png" if MCP_BRASIL_BASE_URL
 # Create the root server
 mcp = FastMCP(
     "mcp-brasil 🇧🇷",
+    version=__version__,
     lifespan=http_lifespan,
     auth=auth,
     icons=[mt.Icon(src=_LOGO_URL, mimeType="image/png")],

--- a/tests/test_root_server.py
+++ b/tests/test_root_server.py
@@ -211,3 +211,19 @@ class TestRootServerToolTags:
             tools = await c.list_tools()
             listar = next((t for t in tools if t.name == "listar_features"), None)
             assert listar is not None
+
+
+class TestRootServerInfo:
+    @pytest.mark.asyncio
+    async def test_serverinfo_announces_package_version(self) -> None:
+        """serverInfo.version must be the mcp-brasil version, not FastMCP's.
+
+        Without an explicit `version=` in the FastMCP constructor, the handshake
+        advertises the FastMCP release (e.g. 3.2.3) instead of the package
+        version, which makes client-side version pinning and bug reports point
+        at the wrong project.
+        """
+        from mcp_brasil import __version__
+
+        async with Client(mcp) as c:
+            assert c.initialize_result.serverInfo.version == __version__


### PR DESCRIPTION
Extraído da **PR #18** de @diretoriaponteprojetos-code — a parte correta e
independente dela.

## Problema

Sem `version=` no construtor do `FastMCP`, o handshake MCP anuncia a versão do
**FastMCP**, não a do `mcp-brasil`. Medido nesta base:

```
versao do pacote mcp-brasil : 0.14.0
versao do fastmcp           : 3.2.3
serverInfo SEM version=     : 3.2.3   ← o que os clientes veem hoje
serverInfo COM version=     : 0.14.0  ← com este fix
```

Consequência: relato de bug e pinagem de versão do lado do cliente apontam
para o projeto errado.

## Mudança

1 linha no construtor + o import de `__version__`, e um teste de handshake que
trava a regressão.

## Sobre o resto da PR #18

O registro lazy segue em discussão em separado — ele precisa de ADR e tem
bloqueantes reproduzidos. Esta parte não depende daquilo e entra sozinha.

## Validação

- `tests/test_root_server.py`: 23 passed
- `ruff check`, `ruff format --check` e `mypy --strict` verdes