### PR TITLE
fix(tabua_mares): migrar para tabuamare.api.br e corrigir tipo de `id`

### DIFF
--- a/src/mcp_brasil/data/tabua_mares/__init__.py
+++ b/src/mcp_brasil/data/tabua_mares/__init__.py
@@ -6,7 +6,7 @@ FEATURE_META = FeatureMeta(
     name="tabua_mares",
     description="Tábua de marés — previsão de marés para portos do litoral brasileiro",
     version="0.1.0",
-    api_base="https://tabuademares.com/api/v2",
+    api_base="https://tabuamare.api.br/api/v2",
     requires_auth=False,
     tags=["mares", "portos", "litoral", "navegacao", "oceanografia"],
 )

--- a/src/mcp_brasil/data/tabua_mares/constants.py
+++ b/src/mcp_brasil/data/tabua_mares/constants.py
@@ -1,7 +1,9 @@
 """Constants for the Tabua Mares feature."""
 
 # API base URL
-TABUA_MARES_BASE = "https://tabuademares.com"
+# O dominio antigo (tabuademares.com) passou a responder 403 e a v1 foi
+# removida pelo mantenedor da API; tudo migrou para tabuamare.api.br (ver #28).
+TABUA_MARES_BASE = "https://tabuamare.api.br"
 TABUA_MARES_API = f"{TABUA_MARES_BASE}/api/v2"
 
 # Endpoints
@@ -11,7 +13,8 @@ HARBORS_URL = f"{TABUA_MARES_API}/harbors"
 TABUA_MARE_URL = f"{TABUA_MARES_API}/tabua-mare"
 NEAREST_HARBOR_URL = f"{TABUA_MARES_API}/nearested-harbor"
 NEAREST_HARBOR_INDEPENDENT_URL = f"{TABUA_MARES_API}/nearest-harbor-independent-state"
-GEO_TABUA_MARE_URL = f"{TABUA_MARES_BASE}/geo-tabua-mare"
+# Antes ficava na raiz do dominio; no dominio novo esta sob /api/v2 (verificado).
+GEO_TABUA_MARE_URL = f"{TABUA_MARES_API}/geo-tabua-mare"
 
 # 17 estados costeiros do Brasil
 ESTADOS_COSTEIROS: dict[str, str] = {

--- a/src/mcp_brasil/data/tabua_mares/schemas.py
+++ b/src/mcp_brasil/data/tabua_mares/schemas.py
@@ -19,7 +19,7 @@ class GeoLocalizacao(BaseModel):
 class Porto(BaseModel):
     """Informações detalhadas de um porto."""
 
-    id: int
+    id: str = Field(description="ID alfanumérico do porto (ex: 'pb01')")
     harbor_name: str
     state: str
     timezone: str
@@ -31,7 +31,7 @@ class Porto(BaseModel):
 class PortoResumo(BaseModel):
     """Resumo de um porto retornado pela listagem por estado."""
 
-    id: int
+    id: str = Field(description="ID alfanumérico do porto (ex: 'pb01')")
     year: int
     harbor_name: str
     data_collection_institution: str

--- a/tests/SHOWCASE.md
+++ b/tests/SHOWCASE.md
@@ -247,8 +247,6 @@ Estas APIs estavam indisponíveis no momento do teste:
 
 | Feature | Tool | Erro |
 |---------|------|------|
-| Tábua de Marés | `listar_estados_costeiros` | HTTP 404 — API tabuademares.com indisponível |
-| Tábua de Marés | `listar_portos` | HTTP 404 — API tabuademares.com indisponível |
 | ANVISA | `buscar_medicamento` | HTTP 403 — Bloqueio da ANVISA (Cloudflare) |
 | ANA | `monitorar_reservatorios` | JSON inválido — API SAR instável |
 

--- a/tests/data/tabua_mares/test_client.py
+++ b/tests/data/tabua_mares/test_client.py
@@ -45,7 +45,7 @@ async def test_listar_portos_estado() -> None:
             json={
                 "data": [
                     {
-                        "id": 27,
+                        "id": "pb01",
                         "year": 2025,
                         "harbor_name": "PORTO DE CABEDELO",
                         "data_collection_institution": "DNPVN",
@@ -69,7 +69,7 @@ async def test_buscar_portos() -> None:
             json={
                 "data": [
                     {
-                        "id": 1,
+                        "id": "pb01",
                         "harbor_name": "PORTO DE CABEDELO",
                         "state": "pb",
                         "timezone": "UTC -03.0",
@@ -138,7 +138,7 @@ async def test_porto_mais_proximo() -> None:
             json={
                 "data": [
                     {
-                        "id": 1,
+                        "id": "pb01",
                         "harbor_name": "PORTO DE CABEDELO",
                         "state": "pb",
                         "timezone": "UTC -03.0",
@@ -164,7 +164,7 @@ async def test_porto_mais_proximo_geral() -> None:
             json={
                 "data": [
                     {
-                        "id": 1,
+                        "id": "pb01",
                         "harbor_name": "PORTO DE CABEDELO",
                         "state": "pb",
                         "timezone": "UTC -03.0",

--- a/tests/data/tabua_mares/test_tools.py
+++ b/tests/data/tabua_mares/test_tools.py
@@ -39,7 +39,7 @@ def ctx() -> AsyncMock:
 @pytest.fixture()
 def sample_porto() -> Porto:
     return Porto(
-        id=1,
+        id="pb01",
         harbor_name="PORTO DE CABEDELO (ESTADO DA PARAÍBA)",
         state="pb",
         timezone="UTC -03.0",
@@ -103,7 +103,7 @@ async def test_listar_portos(ctx: AsyncMock) -> None:
     with patch(f"{MODULE}.listar_portos_estado", new_callable=AsyncMock) as mock:
         mock.return_value = [
             PortoResumo(
-                id=27,
+                id="pb01",
                 year=2025,
                 harbor_name="PORTO DE CABEDELO",
                 data_collection_institution="DNPVN",


### PR DESCRIPTION
Closes #28. Obrigado @Ddiidev pelo aviso — e por se oferecer para fazer o fix.

## O que estava quebrado

```
tabuademares.com/api/v2/states   -> 403
tabuamare.api.br/api/v2/states   -> 200
tabuamare.api.br/api/v1/states   -> 404   (v1 removida, como você disse)
```

## Duas coisas que a issue não mencionava

Testando as 7 funções do client contra a API real, apareceram dois problemas
além da URL:

**1. `geo-tabua-mare` mudou de lugar.** Estava na raiz do domínio; agora está
sob `/api/v2`:

```
tabuamare.api.br/geo-tabua-mare/...          -> 404
tabuamare.api.br/api/v2/geo-tabua-mare/...   -> 200
```

**2. O campo `id` é string, não inteiro.** A API devolve `"pb01"`, mas
`schemas.py` declarava `id: int`. Isso era incoerente com o próprio código —
`buscar_portos` monta a lista com ids alfanuméricos e os docstrings usam
`'pb01'`.

## Por que a suíte não pegou nada disso

As fixtures usavam `"id": 27` e `"id": 1` — valores que a API real nunca
devolveu. O teste media o parser contra a fixture, nunca o contrato contra a
fonte. Substituídas pelo valor real (`"pb01"`, PORTO DE CABEDELO).

O `tests/SHOWCASE.md` inclusive **já registrava** "HTTP 404 — API
tabuademares.com indisponível" para duas tools, mas isso nunca virou issue.
Removi as linhas agora que voltaram a funcionar.

## Validação

Chamando o client de verdade contra a API real:

```
OK  listar_estados: 17 itens
OK  listar_portos_estado(pb): 1 itens
OK  buscar_portos(['pb01']): 1 itens
OK  consultar_tabua_mare('pb01', 8, '1'): 1 itens
OK  porto_mais_proximo: 1 itens
OK  porto_mais_proximo_geral: 1 itens
OK  tabua_mare_por_geolocalizacao: 1 itens
```

Suíte: **2566 passed / 0 failed**; `ruff` e `mypy --strict` verdes.