### PR TITLE
chore(startup): restringir dotenv ao cwd e desligar o banner no stdio

### DIFF
--- a/src/mcp_brasil/server.py
+++ b/src/mcp_brasil/server.py
@@ -317,4 +317,8 @@ else:
 
 
 if __name__ == "__main__":
-    mcp.run()
+    # show_banner=False: no transporte stdio o banner vai para stderr (ruído para
+    # o cliente MCP) e dispara a checagem de versão do FastMCP, que faz um GET
+    # HTTPS a pypi.org com timeout de 2 s. Fora de lugar num servidor local, e
+    # custo fixo em ambiente offline/air-gapped.
+    mcp.run(show_banner=False)

--- a/src/mcp_brasil/settings.py
+++ b/src/mcp_brasil/settings.py
@@ -1,16 +1,25 @@
 """Configuração global do mcp-brasil.
 
 Valores podem ser sobrescritos via variáveis de ambiente.
-Carrega automaticamente o arquivo .env na raiz do projeto.
+Carrega o arquivo `.env` do diretório de trabalho atual, se existir.
+Para apontar outro caminho, use `MCP_BRASIL_DOTENV=/caminho/para/.env`.
 """
 
 from __future__ import annotations
 
 import os
+from pathlib import Path
 
 from dotenv import load_dotenv
 
-load_dotenv()
+# `load_dotenv()` sem argumento SOBE a árvore de diretórios a partir do arquivo
+# que o chamou. Num pacote instalado isso parte de site-packages e pode acabar
+# carregando um `.env` de fora do projeto, injetando credenciais sem que
+# ninguém tenha pedido. Carregamos apenas o `.env` do diretório atual — que é
+# o que a documentação sempre prometeu — com escape hatch explícito.
+_dotenv_path = Path(os.environ.get("MCP_BRASIL_DOTENV", "")) or Path.cwd() / ".env"
+if _dotenv_path.is_file():
+    load_dotenv(_dotenv_path)
 
 # --- HTTP Client ---
 HTTP_TIMEOUT: float = float(os.environ.get("MCP_BRASIL_HTTP_TIMEOUT", "30.0"))


### PR DESCRIPTION
Duas correções de higiene de inicialização, independentes entre si.

## 1. `settings.py` — `.env` de fora do projeto era carregado silenciosamente

`load_dotenv()` sem argumento **sobe a árvore de diretórios** a partir do arquivo
que o chamou. Num pacote instalado isso parte de `site-packages` e pode acabar
carregando um `.env` de fora do projeto — injetando credenciais sem que ninguém
tenha pedido.

Não é hipotético: durante a validação de uma PR nesta auditoria ele resolveu
para um `.env` real fora do repositório **e fora do worktree**, e chegou a
inverter o resultado da primeira medição.

O docstring do arquivo sempre prometeu "o arquivo `.env` na raiz do projeto" —
agora o código faz isso. Escape hatch explícito via `MCP_BRASIL_DOTENV`.

Verificado:

```
sem a env var, com .env num diretório pai  -> NÃO carrega (corrigido)
com MCP_BRASIL_DOTENV=/caminho/.env        -> carrega
```

## 2. `server.py` — `mcp.run(show_banner=False)`

No transporte stdio o banner vai para **stderr** (ruído para o cliente MCP) e
dispara a checagem de versão do FastMCP, que faz um `GET` HTTPS a
`pypi.org/pypi/fastmcp/json` com timeout de 2 s
(`fastmcp/utilities/version_check.py`, cache de 12 h).

Um servidor MCP local contatando o PyPI sem que o usuário tenha pedido é
comportamento questionável, e é custo fixo em ambiente offline ou air-gapped.

Contribui para #15 (esse `GET` é um dos suspeitos do crash de OpenSSL no
Windows), mas **não fecha a issue** — a causa raiz continua não confirmada, e
não temos Windows no CI para verificar.

## Validação

**2566 passed / 0 failed**; `ruff check`, `ruff format --check` e
`mypy --strict` verdes.