### PR TITLE
feat(ci): canary semanal de saúde das fontes de dados

### DIFF
--- a/.github/workflows/canary-sources.yml
+++ b/.github/workflows/canary-sources.yml
@@ -1,0 +1,75 @@
+name: Canary de fontes
+
+# Por que existe: a suíte é 100% mockada (respx), então mede o parser contra a
+# fixture e nunca o contrato contra a fonte. Features já ficaram meses mortas em
+# produção sem nenhum sinal (tce_ce desde 2026-03-23; tabua_mares só apareceu
+# porque um usuário abriu issue).
+
+on:
+  schedule:
+    # Toda segunda 05:00 UTC (02:00 BRT) — depois do refresh de datasets.
+    - cron: "0 5 * * 1"
+  workflow_dispatch:
+
+concurrency:
+  group: canary-sources
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  canary:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+
+      - name: Install Python
+        run: uv python install 3.12
+
+      - name: Sync deps
+        run: uv sync --frozen
+
+      - name: Rodar canary
+        id: canary
+        # Não falha o step: queremos publicar o relatório mesmo com falhas.
+        continue-on-error: true
+        run: |
+          set +e
+          uv run python scripts/canary_sources.py --markdown > relatorio.md
+          echo "exit_code=$?" >> "$GITHUB_OUTPUT"
+          cat relatorio.md
+
+      - name: Publicar no resumo do job
+        run: cat relatorio.md >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Abrir ou atualizar issue
+        if: steps.canary.outputs.exit_code != '0'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TITULO: "[canary] Fontes de dados fora do ar"
+        run: |
+          set -euo pipefail
+          {
+            echo "Relatório automático do canary semanal — execução de $(date -u '+%Y-%m-%d %H:%M UTC')."
+            echo
+            cat relatorio.md
+            echo
+            echo "---"
+            echo "_Gerado por \`.github/workflows/canary-sources.yml\`. Rode localmente com \`uv run python scripts/canary_sources.py\`._"
+          } > corpo.md
+
+          EXISTENTE=$(gh issue list --state open --search "\"$TITULO\" in:title" \
+            --json number,title --jq "[.[] | select(.title == \"$TITULO\")][0].number // empty")
+
+          if [ -n "$EXISTENTE" ]; then
+            gh issue comment "$EXISTENTE" --body-file corpo.md
+            echo "Comentado na issue #$EXISTENTE"
+          else
+            gh issue create --title "$TITULO" --body-file corpo.md
+          fi

--- a/scripts/canary_sources.py
+++ b/scripts/canary_sources.py
@@ -1,0 +1,275 @@
+#!/usr/bin/env python
+"""Canary de saúde das fontes de dados.
+
+Sonda a `api_base` declarada em cada `FEATURE_META` e reporta as que
+aparentam estar fora do ar ou bloqueando o servidor.
+
+Por que existe
+--------------
+A suíte de testes é 100% mockada (`respx`): mede o parser contra a fixture,
+nunca o contrato contra a fonte. Isso deixou passar, sem nenhum sinal,
+features mortas em produção por meses — `tce_ce` ficou 100% fora do ar desde
+2026-03-23 com o README anunciando "4 tools operacionais", e `tabua_mares`
+só foi descoberta porque um usuário abriu issue.
+
+O que ele PEGA
+--------------
+- DNS que não resolve
+- conexão recusada / timeout / erro de TLS, persistindo entre tentativas
+- HTTP 5xx persistente
+
+E sinaliza como ATENÇÃO (não falha):
+- HTTP 401/403 em feature que não declara `requires_auth` — possível WAF novo
+
+O que ele NÃO pega  (leia antes de confiar)
+-------------------------------------------
+Mudança de caminho ou de schema em endpoint específico. A `api_base` de
+várias features **não é um endpoint válido por si só**: `servicodados.ibge.gov.br/api`
+devolve 503 enquanto `/api/v1/localidades/estados` devolve 200. Por isso
+qualquer resposta HTTP conta como "host vivo" — o critério é deliberadamente
+conservador, para que uma issue automática signifique alguma coisa.
+
+Pegar quebra de endpoint exige smoke test por feature, chamando uma URL real
+com parâmetros válidos. Features podem declarar essa URL em `CANARY_URLS`
+abaixo; quando declarada, ela é sondada no lugar da `api_base` e aí sim um
+404 conta como falha.
+
+Uso
+---
+    uv run python scripts/canary_sources.py              # texto
+    uv run python scripts/canary_sources.py --json
+    uv run python scripts/canary_sources.py --markdown
+
+Sai com 1 se houver FALHA; ATENÇÃO sozinha não quebra o build.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import logging
+import sys
+from dataclasses import dataclass, field
+
+import httpx
+
+from mcp_brasil._shared.feature import FeatureRegistry
+
+TIMEOUT = httpx.Timeout(25.0, connect=12.0)
+CONCURRENCY = 6
+TENTATIVAS = 3
+BACKOFF = 3.0
+
+# Navegador-like: vários WAFs gov.br têm denylist de assinaturas de ferramenta
+# (curl, python-httpx, python-requests), o que produziria falso positivo.
+HEADERS = {
+    "User-Agent": (
+        "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 "
+        "(KHTML, like Gecko) Chrome/137.0.0.0 Safari/537.36"
+    ),
+    "Accept": "*/*",
+}
+
+# Endpoints reais, com parâmetros válidos, para features onde a api_base não
+# serve como sonda. Quando presente, um 404/4xx AQUI conta como falha — é o
+# único jeito de pegar mudança de caminho como a que matou tce_ce e tabua_mares.
+# Adicione conforme for validando cada feature ao vivo.
+CANARY_URLS: dict[str, str] = {
+    "ibge": "https://servicodados.ibge.gov.br/api/v1/localidades/estados",
+    "tabua_mares": "https://tabuamare.api.br/api/v2/states",
+    "brasilapi": "https://brasilapi.com.br/api/banks/v1",
+}
+
+
+@dataclass
+class Resultado:
+    feature: str
+    url: str
+    status: int | None = None
+    erro: str | None = None
+    requires_auth: bool = False
+    endpoint_real: bool = False
+    tentativas_gastas: int = 0
+
+    @property
+    def instavel(self) -> bool:
+        """Respondeu, mas só depois de falhar em pelo menos uma tentativa.
+
+        Vários portais gov.br oscilam: `legis.senado.leg.br` respondeu 1 de 5
+        vezes numa medição. Tratar isso como morte gera issue falsa; ignorar
+        esconde degradação real. Fica numa categoria própria.
+        """
+        return self.erro is None and self.status is not None and self.tentativas_gastas > 1
+
+    @property
+    def nivel(self) -> str:
+        """'ok' | 'atencao' | 'falha'."""
+        if self.erro is not None or self.status is None:
+            return "falha"
+        if self.status >= 500:
+            return "falha"
+        # Num endpoint real declarado em CANARY_URLS, 4xx é quebra de contrato.
+        if self.endpoint_real and self.status >= 400:
+            return "falha"
+        if self.status in (401, 403):
+            # Esperado quando a feature declara exigir credencial.
+            return "ok" if self.requires_auth else "atencao"
+        if self.instavel:
+            return "atencao"
+        # Na api_base, qualquer outra resposta HTTP só prova que o host está vivo.
+        return "ok"
+
+    @property
+    def motivo(self) -> str:
+        if self.erro:
+            return f"{self.erro} — {self.tentativas_gastas} tentativa(s), nenhuma respondeu"
+        if self.status in (401, 403):
+            return f"HTTP {self.status} — possível WAF novo ou auth passou a ser exigida"
+        if self.status is not None and self.status >= 500:
+            return f"HTTP {self.status} — erro no servidor da fonte"
+        if self.instavel:
+            return f"instável — HTTP {self.status} só na tentativa {self.tentativas_gastas}"
+        return f"HTTP {self.status}"
+
+
+@dataclass
+class Relatorio:
+    ok: list[Resultado] = field(default_factory=list)
+    atencao: list[Resultado] = field(default_factory=list)
+    falhas: list[Resultado] = field(default_factory=list)
+
+    @property
+    def total(self) -> int:
+        return len(self.ok) + len(self.atencao) + len(self.falhas)
+
+
+async def _probe(
+    client: httpx.AsyncClient, feat: str, url: str, auth: bool, real: bool
+) -> Resultado:
+    r = Resultado(feature=feat, url=url, requires_auth=auth, endpoint_real=real)
+    for tentativa in range(1, TENTATIVAS + 1):
+        r.erro = None
+        r.tentativas_gastas = tentativa
+        try:
+            resp = await client.get(url, headers=HEADERS, follow_redirects=True)
+            r.status = resp.status_code
+            # 5xx pode ser transitório — insiste antes de declarar falha.
+            if resp.status_code < 500:
+                return r
+        except httpx.TimeoutException:
+            r.erro = "timeout"
+        except httpx.ConnectError as exc:
+            r.erro = f"falha de conexão/DNS ({type(exc).__name__})"
+        except httpx.HTTPError as exc:
+            r.erro = f"{type(exc).__name__}: {exc}"
+        if tentativa < TENTATIVAS:
+            await asyncio.sleep(BACKOFF * tentativa)
+    return r
+
+
+def _coletar_fontes() -> list[tuple[str, str, bool, bool]]:
+    reg = FeatureRegistry()
+    reg.discover("mcp_brasil.data")
+    fontes: list[tuple[str, str, bool, bool]] = []
+    for nome, feat in sorted(reg.features.items()):
+        meta = feat.meta
+        override = CANARY_URLS.get(nome)
+        base = override or getattr(meta, "api_base", None)
+        if base:
+            fontes.append(
+                (nome, base, bool(getattr(meta, "requires_auth", False)), override is not None)
+            )
+    return fontes
+
+
+async def rodar() -> Relatorio:
+    fontes = _coletar_fontes()
+    sem = asyncio.Semaphore(CONCURRENCY)
+
+    async with httpx.AsyncClient(timeout=TIMEOUT) as client:
+
+        async def limitado(n: str, u: str, a: bool, r: bool) -> Resultado:
+            async with sem:
+                return await _probe(client, n, u, a, r)
+
+        resultados = await asyncio.gather(*[limitado(*f) for f in fontes])
+
+    rel = Relatorio()
+    for r in resultados:
+        getattr(rel, {"ok": "ok", "atencao": "atencao", "falha": "falhas"}[r.nivel]).append(r)
+    return rel
+
+
+def _tabela(rs: list[Resultado]) -> list[str]:
+    return ["| Feature | URL | Motivo |", "|---|---|---|"] + [
+        f"| `{r.feature}` | {r.url} | {r.motivo} |" for r in sorted(rs, key=lambda x: x.feature)
+    ]
+
+
+def _markdown(rel: Relatorio) -> str:
+    out = [
+        f"**{len(rel.falhas)} falha(s)** e **{len(rel.atencao)} atenção(ões)** "
+        f"em {rel.total} fontes.",
+        "",
+    ]
+    if rel.falhas:
+        out += ["## Falhas", "", *_tabela(rel.falhas), ""]
+    if rel.atencao:
+        out += ["## Atenção (não quebra o build)", "", *_tabela(rel.atencao), ""]
+    if not rel.falhas and not rel.atencao:
+        out.append("Nenhum problema detectado. ✅")
+    out += [
+        "",
+        "> Este canary sonda a `api_base` de cada feature (ou a URL real declarada em "
+        "`CANARY_URLS`). Ele **não** detecta mudança de schema, e na `api_base` qualquer "
+        "resposta HTTP conta como host vivo — vários prefixos devolvem 404/503 por design.",
+    ]
+    return "\n".join(out)
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="Canary de saúde das fontes de dados.")
+    ap.add_argument("--json", action="store_true")
+    ap.add_argument("--markdown", action="store_true")
+    args = ap.parse_args()
+
+    logging.disable(logging.CRITICAL)
+    rel = asyncio.run(rodar())
+
+    if args.json:
+        print(
+            json.dumps(
+                {
+                    "total": rel.total,
+                    "ok": len(rel.ok),
+                    "atencao": [
+                        {"feature": r.feature, "url": r.url, "motivo": r.motivo}
+                        for r in rel.atencao
+                    ],
+                    "falhas": [
+                        {"feature": r.feature, "url": r.url, "motivo": r.motivo}
+                        for r in rel.falhas
+                    ],
+                },
+                ensure_ascii=False,
+                indent=2,
+            )
+        )
+    elif args.markdown:
+        print(_markdown(rel))
+    else:
+        for r in sorted(rel.falhas, key=lambda x: x.feature):
+            print(f"FALHA    {r.feature:<22} {r.motivo:<58} {r.url}")
+        for r in sorted(rel.atencao, key=lambda x: x.feature):
+            print(f"ATENCAO  {r.feature:<22} {r.motivo:<58} {r.url}")
+        print(
+            f"\n{len(rel.ok)} ok / {len(rel.atencao)} atenção / "
+            f"{len(rel.falhas)} falhas de {rel.total}"
+        )
+
+    return 1 if rel.falhas else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Por que

A suíte é **100% mockada** (`respx`): mede o parser contra a fixture, nunca o
contrato contra a fonte. Isso deixou features mortas em produção por meses sem
nenhum sinal:

- `tce_ce` — 100% fora do ar desde 2026-03-23, com o README anunciando "4 tools
  operacionais". Só apareceu porque um terceiro abriu a PR #27.
- `tabua_mares` — só apareceu porque um usuário abriu a #28. O
  `tests/SHOWCASE.md` **já registrava** "HTTP 404" havia meses.

Nenhuma dessas quebras é detectável pela suíte, por construção.

## O que faz

`scripts/canary_sources.py` + workflow semanal que sonda a `api_base` de cada
`FEATURE_META` e abre — ou comenta em — uma issue quando algo cai.

## Desenho: conservador de propósito

Uma primeira versão ingênua acusou **12 de 55** fontes, e metade era falso
positivo. As regras abaixo saíram de medição, não de intuição:

| Regra | Por quê (medido) |
|---|---|
| 3 tentativas com backoff | portais gov.br oscilam |
| na `api_base`, **qualquer** resposta HTTP = host vivo | `servicodados.ibge.gov.br/api` → **503**, mas `/api/v1/localidades/estados` → **200**. Sondar prefixo e exigir 2xx é errado |
| 401/403 sem `requires_auth` → **atenção**, não falha | 5 fontes caem aqui; são WAF, não morte |
| responder só na 2ª/3ª tentativa → **atenção** ("instável") | `legis.senado.leg.br` respondeu **1 de 5** vezes |
| User-Agent de navegador | WAFs gov.br têm denylist de `curl`/`python-httpx` — o UA default derrubaria a conexão e geraria falso positivo |

Para pegar quebra de **caminho** (o caso do `tce_ce`), features podem declarar
em `CANARY_URLS` um endpoint real com parâmetros válidos — ali um 4xx **conta**
como falha. Começa com `ibge`, `tabua_mares` e `brasilapi`; a ideia é crescer
conforme cada feature for validada ao vivo.

## O que ele NÃO faz

Não detecta mudança de **schema**. O `tabua_mares` mudou o tipo de `id` de int
para string e nenhum canary de URL pegaria isso — só chamada real + validação
Pydantic pega. Está documentado no docstring para não virar falsa confiança.

## Primeira execução real

**6 falhas em 51 fontes — nenhuma tinha issue aberta:**

| Feature | Diagnóstico |
|---|---|
| `ibama`, `mj`, `sinesp` | DNS não resolve |
| `tce_rj` | redireciona para **`http://localhost/api/v1/`** — upstream mal configurado |
| `jurisprudencia` | HTTP 202, challenge do AWS WAF — **confirma a #26** |
| `inep` | `api_base` redireciona para a home do gov.br |

Mais 5 em "atenção" (403/401): `ana`, `anvisa`, `bcb_olinda`, `compras`, `tce_sc`.

## Validação

`ruff check` e `ruff format --check` limpos no arquivo novo; suíte **2566
passed / 0 failed** (o canary não toca `src/`).

> Nota: `ruff check scripts/` acusa 2 erros **pré-existentes** em
> `scripts/foundry_agent.py` (`F821 Undefined name 'DEFAULT_ENDPOINT'` — um
> `NameError` esperando acontecer). A CI roda `ruff check src/ tests/` e nunca
> olhou `scripts/`. Deixei fora desta PR para não misturar assuntos.